### PR TITLE
Add missing XFS 3.20 classes

### DIFF
--- a/cen/320/xfsalm.h
+++ b/cen/320/xfsalm.h
@@ -1,0 +1,92 @@
+/******************************************************************************
+*                                                                             *
+* xfsalm.h      XFS – Alarm (ALM) definitions                                 *
+*                                                                             *
+*               Version 3.20  (March 02 2011)                                 *
+*                                                                             *
+******************************************************************************/
+
+#ifndef __INC_XFSALM__H
+#define __INC_XFSALM__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "xfsapi.h"
+
+/*   be aware of alignment   */
+#pragma pack (push, 1)
+
+/* values of WFSALMCAPS.wClass */
+
+#define     WFS_SERVICE_CLASS_ALM               (11)
+#define     WFS_SERVICE_CLASS_VERSION_ALM       0x1403 /*Version 3.20 */
+#define     WFS_SERVICE_CLASS_NAME_ALM          "ALM"
+
+#define     ALM_SERVICE_OFFSET                  (WFS_SERVICE_CLASS_ALM * 100)
+
+/* ALM Info Commands */
+
+#define     WFS_INF_ALM_STATUS                  (ALM_SERVICE_OFFSET + 1)
+#define     WFS_INF_ALM_CAPABILITIES            (ALM_SERVICE_OFFSET + 2)
+
+/* ALM Execute Commands */
+
+#define     WFS_CMD_ALM_SET_ALARM               (ALM_SERVICE_OFFSET + 1)
+#define     WFS_CMD_ALM_RESET_ALARM             (ALM_SERVICE_OFFSET + 2)
+#define     WFS_CMD_ALM_RESET                   (ALM_SERVICE_OFFSET + 3)
+
+/* ALM Messages */
+
+#define     WFS_SRVE_ALM_DEVICE_SET             (ALM_SERVICE_OFFSET + 1)
+#define     WFS_SRVE_ALM_DEVICE_RESET           (ALM_SERVICE_OFFSET + 2)
+
+/* values of WFSALMSTATUS.fwDevice */
+
+#define     WFS_ALM_DEVONLINE                   WFS_STAT_DEVONLINE
+#define     WFS_ALM_DEVOFFLINE                  WFS_STAT_DEVOFFLINE
+#define     WFS_ALM_DEVPOWEROFF                 WFS_STAT_DEVPOWEROFF
+#define     WFS_ALM_DEVNODEVICE                 WFS_STAT_DEVNODEVICE
+#define     WFS_ALM_DEVHWERROR                  WFS_STAT_DEVHWERROR
+#define     WFS_ALM_DEVUSERERROR                WFS_STAT_DEVUSERERROR
+#define     WFS_ALM_DEVBUSY                     WFS_STAT_DEVBUSY
+#define     WFS_ALM_DEVFRAUDATTEMPT             WFS_STAT_DEVFRAUDATTEMPT
+#define     WFS_ALM_DEVPOTENTIALFRAUD           WFS_STAT_DEVPOTENTIALFRAUD
+
+/* values of WFSALMSTATUS.wAntiFraudModule */
+
+#define     WFS_ALM_AFMNOTSUPP                  (0)
+#define     WFS_ALM_AFMOK                       (1)
+#define     WFS_ALM_AFMINOP                     (2)
+#define     WFS_ALM_AFMDEVICEDETECTED           (3)
+#define     WFS_ALM_AFMUNKNOWN                  (4)
+
+
+/*=================================================================*/
+/* ALM Info Command Structures */
+/*=================================================================*/
+
+typedef struct _wfs_alm_status
+{
+    WORD                   fwDevice;
+    BOOL                   bAlarmSet;
+    LPSTR                  lpszExtra;
+    WORD                   wAntiFraudModule;
+} WFSALMSTATUS, *LPWFSALMSTATUS;
+
+typedef struct _wfs_alm_caps
+{
+    WORD                   wClass;
+    BOOL                   bProgrammaticallyDeactivate;
+    LPSTR                  lpszExtra;
+    BOOL                   bAntiFraudModule;
+} WFSALMCAPS, *LPWFSALMCAPS;
+
+/*   restore alignment   */
+#pragma pack(pop)
+
+#ifdef __cplusplus
+}       /*extern "C"*/
+#endif
+#endif    /* __INC_XFSALM__H */

--- a/cen/320/xfsapi.h
+++ b/cen/320/xfsapi.h
@@ -272,7 +272,7 @@ HRESULT extern WINAPI WFSCancelAsyncRequest ( HSERVICE hService, REQUESTID Reque
 
 HRESULT extern WINAPI WFSCancelBlockingCall ( DWORD dwThreadID);
 
-HRESULT extern WINAPI WFSCleanUp ();
+HRESULT extern WINAPI WFSCleanUp ( void);
 
 HRESULT extern WINAPI WFSClose ( HSERVICE hService);
 
@@ -296,7 +296,7 @@ HRESULT extern WINAPI WFSGetInfo ( HSERVICE hService, DWORD dwCategory, LPVOID l
 
 HRESULT extern WINAPI WFSAsyncGetInfo ( HSERVICE hService, DWORD dwCategory, LPVOID lpQueryDetails, DWORD dwTimeOut, HWND hWnd, LPREQUESTID lpRequestID);
 
-BOOL extern WINAPI WFSIsBlocking ();
+BOOL extern WINAPI WFSIsBlocking ( void);
 
 HRESULT extern WINAPI WFSLock ( HSERVICE hService, DWORD dwTimeOut, LPWFSRESULT * lppResult);
 
@@ -314,7 +314,7 @@ HRESULT extern WINAPI WFSSetBlockingHook ( XFSBLOCKINGHOOK lpBlockFunc, LPXFSBLO
 
 HRESULT extern WINAPI WFSStartUp ( DWORD dwVersionsRequired, LPWFSVERSION lpWFSVersion);
 
-HRESULT extern WINAPI WFSUnhookBlockingHook ();
+HRESULT extern WINAPI WFSUnhookBlockingHook ( void);
 
 HRESULT extern WINAPI WFSUnlock ( HSERVICE hService);
 

--- a/cen/320/xfscam.h
+++ b/cen/320/xfscam.h
@@ -1,0 +1,177 @@
+/******************************************************************************
+*                                                                             *
+* xfscam.h      XFS - Camera (CAM) definitions                                *
+*                                                                             *
+*             Version 3.20  (March 02 2011)                                   *
+*                                                                             *
+******************************************************************************/
+
+#ifndef __INC_XFSCAM__H
+#define __INC_XFSCAM__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "xfsapi.h"
+
+/* be aware of alignment */
+#pragma pack (push, 1)
+
+/* values of WFSCAMCAPS.wClass */
+
+#define     WFS_SERVICE_CLASS_CAM               (10)
+#define     WFS_SERVICE_VERSION_CAM             (0x1403) /* Version 3.20 */
+#define     WFS_SERVICE_NAME_CAM                "CAM"
+
+#define     CAM_SERVICE_OFFSET                  (WFS_SERVICE_CLASS_CAM * 100)
+
+/* CAM Info Commands */
+
+#define     WFS_INF_CAM_STATUS                  (CAM_SERVICE_OFFSET + 1)
+#define     WFS_INF_CAM_CAPABILITIES            (CAM_SERVICE_OFFSET + 2)
+
+/* CAM Execute Commands */
+
+#define     WFS_CMD_CAM_TAKE_PICTURE            (CAM_SERVICE_OFFSET + 1)
+#define     WFS_CMD_CAM_RESET                   (CAM_SERVICE_OFFSET + 2)
+#define     WFS_CMD_CAM_TAKE_PICTURE_EX         (CAM_SERVICE_OFFSET + 3)
+
+/* CAM Messages */
+
+#define     WFS_USRE_CAM_MEDIATHRESHOLD         (CAM_SERVICE_OFFSET + 1)
+#define     WFS_EXEE_CAM_INVALIDDATA            (CAM_SERVICE_OFFSET + 2)
+
+/* values of WFSCAMSTATUS.fwDevice */
+
+#define     WFS_CAM_DEVONLINE                   WFS_STAT_DEVONLINE
+#define     WFS_CAM_DEVOFFLINE                  WFS_STAT_DEVOFFLINE
+#define     WFS_CAM_DEVPOWEROFF                 WFS_STAT_DEVPOWEROFF
+#define     WFS_CAM_DEVNODEVICE                 WFS_STAT_DEVNODEVICE
+#define     WFS_CAM_DEVHWERROR                  WFS_STAT_DEVHWERROR
+#define     WFS_CAM_DEVUSERERROR                WFS_STAT_DEVUSERERROR
+#define     WFS_CAM_DEVBUSY                     WFS_STAT_DEVBUSY
+#define     WFS_CAM_DEVFRAUDATTEMPT             WFS_STAT_DEVFRAUDATTEMPT
+#define     WFS_CAM_DEVPOTENTIALFRAUD           WFS_STAT_DEVPOTENTIALFRAUD
+
+/* number of cameras supported/length of WFSCAMSTATUS.fwCameras field */
+
+#define     WFS_CAM_CAMERAS_SIZE                (8)
+#define     WFS_CAM_CAMERAS_MAX                 (WFS_CAM_CAMERAS_SIZE - 1)
+
+/* indices of WFSCAMSTATUS.fwMedia[...]
+              WFSCAMSTATUS.fwCameras [...]
+              WFSCAMSTATUS.usPictures[...]
+              WFSCAMCAPS.fwCameras [...]
+              WFSCAMTAKEPICT.wCamera             */
+
+#define     WFS_CAM_ROOM                        (0)
+#define     WFS_CAM_PERSON                      (1)
+#define     WFS_CAM_EXITSLOT                    (2)
+
+/* values of WFSCAMSTATUS.fwMedia */
+
+#define     WFS_CAM_MEDIAOK                     (0)
+#define     WFS_CAM_MEDIAHIGH                   (1)
+#define     WFS_CAM_MEDIAFULL                   (2)
+#define     WFS_CAM_MEDIAUNKNOWN                (3)
+#define     WFS_CAM_MEDIANOTSUPP                (4)
+
+/* values of WFSCAMSTATUS.fwCameras */
+
+#define     WFS_CAM_CAMNOTSUPP                  (0)
+#define     WFS_CAM_CAMOK                       (1)
+#define     WFS_CAM_CAMINOP                     (2)
+#define     WFS_CAM_CAMUNKNOWN                  (3)
+
+/* values of WFSCAMCAPS.fwType */
+
+#define     WFS_CAM_TYPE_CAM                    (1)
+
+/* values of WFSCAMCAPS.fwCameras */
+
+#define     WFS_CAM_NOT_AVAILABLE               (0)
+#define     WFS_CAM_AVAILABLE                   (1)
+
+/* values of WFSCAMCAPS.fwCamData */
+
+#define     WFS_CAM_NOTADD                      (0)
+#define     WFS_CAM_AUTOADD                     (1)
+#define     WFS_CAM_MANADD                      (2)
+
+/* values of WFSCAMCAPS.fwCharSupport */
+
+#define     WFS_CAM_ASCII                       (0x0001)
+#define     WFS_CAM_UNICODE                     (0x0002)
+
+/* values of WFSCAMSTATUS.wAntiFraudModule */
+
+#define     WFS_CAM_AFMNOTSUPP                  (0)
+#define     WFS_CAM_AFMOK                       (1)
+#define     WFS_CAM_AFMINOP                     (2)
+#define     WFS_CAM_AFMDEVICEDETECTED           (3)
+#define     WFS_CAM_AFMUNKNOWN                  (4)
+
+/* XFS CAM Errors */ 
+
+#define WFS_ERR_CAM_CAMNOTSUPP                  (-(CAM_SERVICE_OFFSET + 0))
+#define WFS_ERR_CAM_MEDIAFULL                   (-(CAM_SERVICE_OFFSET + 1))
+#define WFS_ERR_CAM_CAMINOP                     (-(CAM_SERVICE_OFFSET + 2))
+#define WFS_ERR_CAM_CHARSETNOTSUPP              (-(CAM_SERVICE_OFFSET + 3))
+#define WFS_ERR_CAM_FILEIOERROR                 (-(CAM_SERVICE_OFFSET + 4))
+
+/*=================================================================*/
+/* CAM Info Command Structures */
+/*=================================================================*/
+
+typedef struct _wfs_cam_status
+{
+    WORD             fwDevice;
+    WORD             fwMedia[WFS_CAM_CAMERAS_SIZE];
+    WORD             fwCameras[WFS_CAM_CAMERAS_SIZE];
+    USHORT           usPictures[WFS_CAM_CAMERAS_SIZE];
+    LPSTR            lpszExtra;
+    WORD             wAntiFraudModule;
+} WFSCAMSTATUS, *LPWFSCAMSTATUS;
+
+typedef struct _wfs_cam_caps
+{
+    WORD             wClass;
+    WORD             fwType;
+    WORD             fwCameras[WFS_CAM_CAMERAS_SIZE];
+    USHORT           usMaxPictures;
+    WORD             fwCamData;
+    USHORT           usMaxDataLength;
+    WORD             fwCharSupport;
+    LPSTR            lpszExtra;
+    BOOL             bPictureFile;
+    BOOL             bAntiFraudModule;
+} WFSCAMCAPS, *LPWFSCAMCAPS;
+
+/*=================================================================*/
+/* CAM Execute Command Structures */
+/*=================================================================*/
+
+typedef struct _wfs_cam_take_picture
+{
+    WORD             wCamera;
+    LPSTR            lpszCamData;
+    LPWSTR           lpszUNICODECamData;
+} WFSCAMTAKEPICT, *LPWFSCAMTAKEPICT;
+
+typedef struct _wfs_cam_take_picture_ex
+{
+    WORD             wCamera;
+    LPSTR            lpszCamData;
+    LPWSTR           lpszUNICODECamData;
+    LPSTR            lpszPictureFile;
+} WFSCAMTAKEPICTEX, *LPWFSCAMTAKEPICTEX;
+
+/* restore alignment */
+#pragma pack (pop)
+
+#ifdef __cplusplus
+}       /*extern "C"*/
+#endif
+
+#endif  /* __INC_XFSCAM__H */

--- a/cen/320/xfsceu.h
+++ b/cen/320/xfsceu.h
@@ -1,0 +1,405 @@
+/******************************************************************************
+*                                                                             *
+* xfsceu.h    XFS - Card Embossing Unit (CEU) definitions                     *
+*                                                                             *
+*             Version 3.20  (March 02 2011)                                   *
+*                                                                             *
+******************************************************************************/
+
+#ifndef __INC_XFSCEU__H
+#define __INC_XFSCEU__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "xfsapi.h"
+
+/*   be aware of alignment   */
+#pragma pack(push,1)
+
+
+/* values of WFSCEUCAPS.wClass */
+
+#define     WFS_SERVICE_CLASS_CEU               (12)
+#define     WFS_SERVICE_CLASS_NAME_CEU          "CEU"
+#define     WFS_SERVICE_CLASS_VERSION_CEU       (0x1403) /* Version 3.20 */
+
+#define     CEU_SERVICE_OFFSET                  (WFS_SERVICE_CLASS_CEU * 100)
+
+/* CEU Info Commands */
+
+#define     WFS_INF_CEU_STATUS                  (CEU_SERVICE_OFFSET + 1)
+#define     WFS_INF_CEU_CAPABILITIES            (CEU_SERVICE_OFFSET + 2)
+#define     WFS_INF_CEU_FORM_LIST               (CEU_SERVICE_OFFSET + 3)
+#define     WFS_INF_CEU_QUERY_FORM              (CEU_SERVICE_OFFSET + 4)
+#define     WFS_INF_CEU_MEDIA_LIST              (CEU_SERVICE_OFFSET + 5)
+#define     WFS_INF_CEU_QUERY_MEDIA             (CEU_SERVICE_OFFSET + 6)
+#define     WFS_INF_CEU_QUERY_FIELD             (CEU_SERVICE_OFFSET + 7)
+
+/* CEU Execute Commands */
+
+#define     WFS_CMD_CEU_EMBOSS_CARD             (CEU_SERVICE_OFFSET + 1)
+#define     WFS_CMD_CEU_RESET                   (CEU_SERVICE_OFFSET + 2)
+#define     WFS_CMD_CEU_POWER_SAVE_CONTROL      (CEU_SERVICE_OFFSET + 3)
+#define     WFS_CMD_CEU_EMBOSS_CARD_EX          (CEU_SERVICE_OFFSET + 4)
+#define     WFS_CMD_CEU_SUPPLY_REPLENISH        (CEU_SERVICE_OFFSET + 5)
+
+
+/* CEU Messages */
+
+#define     WFS_SRVE_CEU_INPUTBINTHRESHOLD      (CEU_SERVICE_OFFSET + 1)
+#define     WFS_SRVE_CEU_OUTPUTBINTHRESHOLD     (CEU_SERVICE_OFFSET + 2)
+#define     WFS_SRVE_CEU_RETAINBINTHRESHOLD     (CEU_SERVICE_OFFSET + 3)
+#define     WFS_EXEE_CEU_FIELDERROR             (CEU_SERVICE_OFFSET + 4)
+#define     WFS_EXEE_CEU_FIELDWARNING           (CEU_SERVICE_OFFSET + 5)
+#define     WFS_EXEE_CEU_EMBOSS_FAILURE         (CEU_SERVICE_OFFSET + 6)
+#define     WFS_SRVE_CEU_MEDIAREMOVED           (CEU_SERVICE_OFFSET + 7)
+#define     WFS_SRVE_CEU_MEDIADETECTED          (CEU_SERVICE_OFFSET + 8)
+#define     WFS_SRVE_CEU_DEVICEPOSITION         (CEU_SERVICE_OFFSET + 9)
+#define     WFS_SRVE_CEU_POWER_SAVE_CHANGE      (CEU_SERVICE_OFFSET + 10)
+#define     WFS_USRE_CEU_TONERTHRESHOLD         (CEU_SERVICE_OFFSET + 11)
+
+
+/* values of WFSCEUSTATUS.fwDevice */
+
+#define     WFS_CEU_DEVONLINE                   WFS_STAT_DEVONLINE
+#define     WFS_CEU_DEVOFFLINE                  WFS_STAT_DEVOFFLINE
+#define     WFS_CEU_DEVPOWEROFF                 WFS_STAT_DEVPOWEROFF
+#define     WFS_CEU_DEVNODEVICE                 WFS_STAT_DEVNODEVICE
+#define     WFS_CEU_DEVHWERROR                  WFS_STAT_DEVHWERROR
+#define     WFS_CEU_DEVUSERERROR                WFS_STAT_DEVUSERERROR
+#define     WFS_CEU_DEVBUSY                     WFS_STAT_DEVBUSY
+#define     WFS_CEU_DEVFRAUDATTEMPT             WFS_STAT_DEVFRAUDATTEMPT
+#define     WFS_CEU_DEVPOTENTIALFRAUD           WFS_STAT_DEVPOTENTIALFRAUD
+
+/* values of WFSCEUSTATUS.fwMedia  */
+
+#define     WFS_CEU_MEDIAPRESENT                (1)
+#define     WFS_CEU_MEDIANOTPRESENT             (2)
+#define     WFS_CEU_MEDIAJAMMED                 (3)
+#define     WFS_CEU_MEDIANOTSUPP                (4)
+#define     WFS_CEU_MEDIAUNKNOWN                (5)
+#define     WFS_CEU_MEDIAENTERING               (6)
+#define     WFS_CEU_MEDIATOPPER                 (7)
+#define     WFS_CEU_MEDIAINHOPPER               (8)
+#define     WFS_CEU_MEDIAOUTHOPPER              (9)
+#define     WFS_CEU_MEDIAMSRE                   (10)
+#define     WFS_CEU_MEDIARETAINED               (11)
+#define     WFS_CEU_MEDIAREMOVED                (12)
+
+/* values of WFSCEUSTATUS.fwRetainBin  */
+
+#define     WFS_CEU_RETAINBINOK                 (1)
+#define     WFS_CEU_RETAINBINFULL               (2)
+#define     WFS_CEU_RETAINBINHIGH               (3)
+#define     WFS_CEU_RETAINBINNOTSUPP            (4)
+
+/* values of WFSCEUSTATUS.fwOutputBin  */
+
+#define     WFS_CEU_OUTPUTBINOK                 (1)
+#define     WFS_CEU_OUTPUTBINFULL               (2)
+#define     WFS_CEU_OUTPUTBINHIGH               (3)
+#define     WFS_CEU_OUTPUTNOTSUPP               (4)
+
+/* values of WFSCEUSTATUS.fwInputBin  */
+
+#define     WFS_CEU_INPUTBINOK                  (1)
+#define     WFS_CEU_INPUTBINEMPTY               (2)
+#define     WFS_CEU_INPUTBINLOW                 (3)
+#define     WFS_CEU_INPUTNOTSUPP                (4)
+
+/* values of WFSCEUSTATUS.wDevicePosition
+             WFSCEUDEVICEPOSITION.wPosition */
+
+#define     WFS_CEU_DEVICEINPOSITION            (0)
+#define     WFS_CEU_DEVICENOTINPOSITION         (1)
+#define     WFS_CEU_DEVICEPOSUNKNOWN            (2)
+#define     WFS_CEU_DEVICEPOSNOTSUPP            (3)
+
+/* values of WFSCEUSTATUS.wToner  */
+
+#define     WFS_CEU_TONERFULL                   (1)
+#define     WFS_CEU_TONERLOW                    (2)
+#define     WFS_CEU_TONEROUT                    (3)
+#define     WFS_CEU_TONERNOTSUPP                (4)
+#define     WFS_CEU_TONERUNKNOWN                (5)
+
+/* values of WFSCEUCAPS.fwCharSupport,
+             WFSCEUFORM.fwCharSupport  */
+
+#define    WFS_CEU_ASCII                        (0x0001)
+#define    WFS_CEU_UNICODE                      (0x0002)
+
+/* values of WFSCEUCAPS.fwType  */
+
+#define    WFS_CEU_EMBOSS                       (0x0001)
+#define    WFS_CEU_PRINT                        (0x0002)
+
+/* values of WFSCEUFRMMEDIA.wBase  */
+
+#define     WFS_CEU_INCH                        (1)
+#define     WFS_CEU_MM                          (2)
+#define     WFS_CEU_ROWCOLUMN                   (3)
+
+/* values of WFSCEUFRMMEDIA.fwMediaType  */
+
+#define     WFS_CEU_MEDIAECARD                  (1)
+#define     WFS_CEU_MEDIAPCARD                  (2)
+
+/* values of WFSCEUFRMFIELD.fwType  */
+
+#define     WFS_CEU_FIELDTEXT                   (1)
+#define     WFS_CEU_FIELDOCR                    (2)
+
+/* values of WFSCEUFRMFIELD.fwClass  */
+
+#define     WFS_CEU_CLASSSTATIC                 (1)
+#define     WFS_CEU_CLASSOPTIONAL               (2)
+#define     WFS_CEU_CLASSREQUIRED               (3)
+
+/* values WFSCEUFIELDFAIL.wFailure */
+
+#define     WFS_CEU_FIELDREQUIRED               (1)
+#define     WFS_CEU_FIELDSTATICOVWR             (2)
+#define     WFS_CEU_FIELDOVERFLOW               (3)
+#define     WFS_CEU_FIELDNOTFOUND               (4)
+#define     WFS_CEU_FIELDNOTREAD                (5)
+#define     WFS_CEU_FIELDNOTWRITE               (6)
+#define     WFS_CEU_FIELDHWERROR                (7)
+#define     WFS_CEU_FIELDTYPENOTSUPPORTED       (8)
+#define     WFS_CEU_CHARSETFORM                 (9)
+
+/* values of WFSCEUEMBOSSCARD.fwChipProtocols
+             WFSCEUEMBOSSCARDEX.fwChipProtocols  */
+
+#define     WFS_CEU_NOTSUPP                     (0x0000)
+#define     WFS_CEU_CHIPT0                      (0x0001)
+#define     WFS_CEU_CHIPT1                      (0x0002)
+#define     WFS_CEU_CHIP_PROTOCOL_NOT_REQUIRED  (0x0004)
+
+/* values of WFSCEUSUPPLYREPLEN.fwSupplyReplen  */
+
+#define     WFS_CEU_REPLEN_TONER                (0x0001)
+#define     WFS_CEU_REPLEN_INPUTBIN             (0x0002)
+
+/* WFS_EXEE_CEU_EMBOSS_FAILURE  Flags  */
+
+#define     WFS_CEU_STEPPER_ERROR               (1)
+#define     WFS_CEU_TOPPER_FOIL_BREAK           (2)
+#define     WFS_CEU_CARD_FEED_ERROR             (3)
+#define     WFS_CEU_MAGNETIC_STRIPE_ERROR       (4)
+#define     WFS_CEU_RETAIN_BIN_FULL             (5)
+#define     WFS_CEU_OUTPUT_BIN_FULL             (6)
+#define     WFS_CEU_COVER_OPEN                  (7)
+#define     WFS_CEU_TOPPER_JAM                  (8)
+#define     WFS_CEU_STACKER_ERROR               (9)
+#define     WFS_CEU_SYSTEM_ERROR                (10)
+#define     WFS_CEU_OCR_ERROR                   (11)
+#define     WFS_CEU_EMBOSS_LIMITS_EXCEEDED      (12)
+#define     WFS_CEU_COMMUNICATIONS_FAILURE      (13)
+#define     WFS_CEU_DATA_FORMAT_ERROR           (14)
+#define     WFS_CEU_BUFFER_OVERRUN              (15)
+#define     WFS_CEU_PRE_ENCODE_READ_ERROR       (16)
+#define     WFS_CEU_PRE_ENCODE_DATA_MATCH_ERROR (17)
+#define     WFS_CEU_INPUT_BIN_EMPTY             (18)
+#define     WFS_CEU_DEVICE_BUSY                 (19)
+#define     WFS_CEU_TONER_OUT_ERROR             (20)
+#define     WFS_CEU_MEDIA_JAM                   (21)
+
+/* values of lpwCeuMediacontrol parameter of WFS_CMD_CEU_RESET command */
+
+#define     WFS_CEU_CTRLTOINPUTBIN              (1)
+#define     WFS_CEU_CTRLTOOUTPUTBIN             (2)
+#define     WFS_CEU_CTRLTORETAINBIN             (3)
+
+
+/* WOSA/XFS CEU Errors */
+
+#define WFS_ERR_CEU_FORMNOTFOUND                (-(CEU_SERVICE_OFFSET + 1))
+#define WFS_ERR_CEU_FORMINVALID                 (-(CEU_SERVICE_OFFSET + 2))
+#define WFS_ERR_CEU_MEDIANOTFOUND               (-(CEU_SERVICE_OFFSET + 3))
+#define WFS_ERR_CEU_MEDIAINVALID                (-(CEU_SERVICE_OFFSET + 4))
+#define WFS_ERR_CEU_NOMEDIA                     (-(CEU_SERVICE_OFFSET + 5))
+#define WFS_ERR_CEU_MEDIAOVERFLOW               (-(CEU_SERVICE_OFFSET + 6))
+#define WFS_ERR_CEU_IDC_FORMNOTFOUND            (-(CEU_SERVICE_OFFSET + 7))
+#define WFS_ERR_CEU_IDC_FORMINVALID             (-(CEU_SERVICE_OFFSET + 8))
+#define WFS_ERR_CEU_INVALIDDATA                 (-(CEU_SERVICE_OFFSET + 9))
+#define WFS_ERR_CEU_PROTOCOLNOTSUPP             (-(CEU_SERVICE_OFFSET + 10))
+#define WFS_ERR_CEU_ATRNOTOBTAINED              (-(CEU_SERVICE_OFFSET + 11))
+#define WFS_ERR_CEU_FIELDSPECFAILURE            (-(CEU_SERVICE_OFFSET + 12))
+#define WFS_ERR_CEU_FIELDERROR                  (-(CEU_SERVICE_OFFSET + 13))
+#define WFS_ERR_CEU_EMBOSSFAILURE               (-(CEU_SERVICE_OFFSET + 14))
+#define WFS_ERR_CEU_FIELDNOTFOUND               (-(CEU_SERVICE_OFFSET + 15))
+#define WFS_ERR_CEU_POWERSAVETOOSHORT           (-(CEU_SERVICE_OFFSET + 16))
+#define WFS_ERR_CEU_POWERSAVEMEDIAPRESENT       (-(CEU_SERVICE_OFFSET + 17))
+#define WFS_ERR_CEU_CHARSETDATA                 (-(CEU_SERVICE_OFFSET + 18))
+/* values of WFSCEUSTATUS.wAntiFraudModule */
+
+#define     WFS_CEU_AFMNOTSUPP                  (0)
+#define     WFS_CEU_AFMOK                       (1)
+#define     WFS_CEU_AFMINOP                     (2)
+#define     WFS_CEU_AFMDEVICEDETECTED           (3)
+#define     WFS_CEU_AFMUNKNOWN                  (4)
+
+
+/*=================================================================*/
+/* CEU Info Command Structures and variables */
+/*=================================================================*/
+
+typedef struct _wfs_ceu_status
+{
+    WORD            fwDevice;
+    WORD            fwMedia;
+    WORD            fwRetainBin;
+    WORD            fwOutputBin;
+    WORD            fwInputBin;
+    USHORT          usTotalCards;
+    USHORT          usOutputCards;
+    USHORT          usRetainCards;
+    LPSTR           lpszExtra;
+    WORD            wDevicePosition;
+    USHORT          usPowerSaveRecoveryTime;
+    WORD            wToner;
+    WORD            wAntiFraudModule;
+} WFSCEUSTATUS, *LPWFSCEUSTATUS;
+
+typedef struct _wfs_ceu_caps
+{
+    WORD            wClass;
+    BOOL            bCompound;
+    BOOL            bCompareMagneticStripe;
+    BOOL            bMagneticStripeRead;
+    BOOL            bMagneticStripeWrite;
+    BOOL            bChipIO;
+    WORD            wChipProtocol;
+    LPSTR           lpszExtra;
+    BOOL            bPowerSaveControl;
+    WORD            fwCharSupport;
+    WORD            fwType;
+    BOOL            bAntiFraudModule;
+} WFSCEUCAPS, *LPWFSCEUCAPS;
+
+
+typedef struct _wfs_ceu_form
+{
+    LPSTR           lpszFormName;
+    LPSTR           lpszFields;
+    WORD            fwCharSupport;
+    WORD            wLanguageID;
+} WFSCEUFORM, *LPWFSCEUFORM;
+
+typedef struct _wfs_ceu_frm_media
+{
+    WORD            fwMediaType;
+    WORD            wBase;
+    WORD            wUnitX;
+    WORD            wUnitY;
+    WORD            wSizeWidth;
+    WORD            wSizeHeight;
+    WORD            wEmbossAreaX;
+    WORD            wEmbossAreaY;
+    WORD            wEmbossAreaWidth;
+    WORD            wEmbossAreaHeight;
+    WORD            wRestrictedAreaX;
+    WORD            wRestrictedAreaY;
+    WORD            wRestrictedAreaWidth;
+    WORD            wRestrictedAreaHeight;
+} WFSCEUFRMMEDIA, *LPWFSCEUFRMMEDIA;
+
+typedef struct _wfs_ceu_query_field
+{
+    LPSTR           lpszFormName;
+    LPSTR           lpszFieldName;
+} WFSCEUQUERYFIELD, *LPWFSCEUQUERYFIELD;
+
+typedef struct _wfs_ceu_frm_field
+{
+    LPSTR           lpszFieldName;
+    WORD            fwType;
+    WORD            fwClass;
+    LPSTR           lpszInitialValue;
+    LPSTR           lpszFormat;
+    LPWSTR          lpszUNICODEInitialValue;
+    LPWSTR          lpszUNICODEFormat;
+    WORD            wLanguageID;
+} WFSCEUFRMFIELD, *LPWFSCEUFRMFIELD;
+
+/*=================================================================*/
+/* CEU Execute Command Structures */
+/*=================================================================*/
+
+typedef struct _wfs_ceu_emboss_card
+{
+    LPSTR           lpszFormName;
+    LPSTR           lpszMediaName;
+    LPSTR           lpszFields;
+    LPSTR           lpszCompareFormIOFormName;
+    LPSTR           lpszCompareFormIOTrackData;
+    LPSTR           lpszFormIOFormName;
+    LPSTR           lpszFormIOTrackData;
+    WORD            wChipProtocol;
+    ULONG           ulChipDataLength;
+    LPBYTE          lpbChipData;
+} WFSCEUEMBOSSCARD, *LPWFSCEUEMBOSSCARD;
+
+typedef struct _wfs_ceu_power_save_control
+{
+    USHORT          usMaxPowerSaveRecoveryTime;
+} WFSCEUPOWERSAVECONTROL, *LPWFSCEUPOWERSAVECONTROL;
+
+typedef struct _wfs_ceu_emboss_card_ex
+{
+    LPSTR           lpszFormName;
+    LPSTR           lpszMediaName;
+    LPSTR           lpszFields;
+    LPSTR           lpszCompareFormIOFormName;
+    LPSTR           lpszCompareFormIOTrackData;
+    LPSTR           lpszFormIOFormName;
+    LPSTR           lpszFormIOTrackData;
+    WORD            wChipProtocol;
+    ULONG           ulChipDataLength;
+    LPBYTE          lpbChipData;
+    LPWSTR          lpszUNICODEFields;
+} WFSCEUEMBOSSCARDEX, *LPWFSCEUEMBOSSCARDEX;
+
+typedef struct _wfs_ceu_supply_replen
+{
+    WORD            fwSupplyReplen;
+} WFSCEUSUPPLYREPLEN, *LPWFSCEUSUPPLYREPLEN;
+
+/*=================================================================*/
+/* CEU Message Structures */
+/*=================================================================*/
+
+typedef struct _wfs_ceu_field_failure
+{
+    LPSTR           lpszFormName;
+    LPSTR           lpszFieldName;
+    WORD            wFailure;
+} WFSCEUFIELDFAIL, *LPWFSCEUFIELDFAIL;
+
+typedef struct _wfs_ceu_device_position
+{
+    WORD            wPosition;
+} WFSCEUDEVICEPOSITION, *LPWFSCEUDEVICEPOSITION;
+
+typedef struct _wfs_ceu_power_save_change
+{
+    USHORT          usPowerSaveRecoveryTime;
+} WFSCEUPOWERSAVECHANGE, *LPWFSCEUPOWERSAVECHANGE;
+
+typedef struct _wfs_ceu_toner_status
+{
+    LPWORD          lpwTonerThreshold;
+} WFSCEUTONERSTATUS, *LPWFSCEUTONERSTATUS;
+
+/* restore alignment */
+#pragma pack(pop)
+
+#ifdef __cplusplus
+}       /*extern "C"*/
+#endif
+
+#endif  /* __INC_XFSCEU__H */
+

--- a/cen/320/xfscrd.h
+++ b/cen/320/xfscrd.h
@@ -1,0 +1,311 @@
+/******************************************************************************
+*                                                                             *
+* xfscrd.h    XFS - Card Dispenser (CRD) definitions                          *
+*                                                                             *
+*             Version 3.20  (March 02 2011)                                   *
+*                                                                             *
+******************************************************************************/
+
+#ifndef __INC_XFSCRD__H
+#define __INC_XFSCRD__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "xfsapi.h"
+
+/*   be aware of alignment   */
+#pragma pack(push,1)
+
+/* values of WFSCRDCAPS.wClass */
+
+#define     WFS_SERVICE_CLASS_CRD               (14)
+#define     WFS_SERVICE_CLASS_VERSION_CRD       (0x1403) /* Version 3.20 */
+#define     WFS_SERVICE_CLASS_NAME_CRD          "CRD"
+
+#define     CRD_SERVICE_OFFSET                  (WFS_SERVICE_CLASS_CRD * 100)
+
+/* CRD Info Commands */
+
+#define     WFS_INF_CRD_STATUS                  (CRD_SERVICE_OFFSET + 1)
+#define     WFS_INF_CRD_CAPABILITIES            (CRD_SERVICE_OFFSET + 2)
+#define     WFS_INF_CRD_CARD_UNIT_INFO          (CRD_SERVICE_OFFSET + 3)
+
+/* CRD Execute Commands */
+
+#define     WFS_CMD_CRD_DISPENSE_CARD           (CRD_SERVICE_OFFSET + 1)
+#define     WFS_CMD_CRD_EJECT_CARD              (CRD_SERVICE_OFFSET + 2)
+#define     WFS_CMD_CRD_RETAIN_CARD             (CRD_SERVICE_OFFSET + 3)
+#define     WFS_CMD_CRD_RESET                   (CRD_SERVICE_OFFSET + 4)
+#define     WFS_CMD_CRD_SET_GUIDANCE_LIGHT      (CRD_SERVICE_OFFSET + 5)
+#define     WFS_CMD_CRD_SET_CARD_UNIT_INFO      (CRD_SERVICE_OFFSET + 6)
+#define     WFS_CMD_CRD_POWER_SAVE_CONTROL      (CRD_SERVICE_OFFSET + 7)
+
+/* CRD Events  */
+
+#define     WFS_SRVE_CRD_MEDIAREMOVED           (CRD_SERVICE_OFFSET + 1)
+#define     WFS_SRVE_CRD_CARDUNITINFOCHANGED    (CRD_SERVICE_OFFSET + 2)
+#define     WFS_SRVE_CRD_MEDIADETECTED          (CRD_SERVICE_OFFSET + 3)
+#define     WFS_USRE_CRD_CARDUNITTHRESHOLD      (CRD_SERVICE_OFFSET + 4)
+#define     WFS_EXEE_CRD_CARDUNITERROR          (CRD_SERVICE_OFFSET + 5)
+#define     WFS_SRVE_CRD_DEVICEPOSITION         (CRD_SERVICE_OFFSET + 6)
+#define     WFS_SRVE_CRD_POWER_SAVE_CHANGE      (CRD_SERVICE_OFFSET + 7)
+
+/* values of WFSCRDSTATUS.fwDevice */
+
+#define     WFS_CRD_DEVONLINE                   WFS_STAT_DEVONLINE
+#define     WFS_CRD_DEVOFFLINE                  WFS_STAT_DEVOFFLINE
+#define     WFS_CRD_DEVPOWEROFF                 WFS_STAT_DEVPOWEROFF
+#define     WFS_CRD_DEVNODEVICE                 WFS_STAT_DEVNODEVICE
+#define     WFS_CRD_DEVHWERROR                  WFS_STAT_DEVHWERROR
+#define     WFS_CRD_DEVUSERERROR                WFS_STAT_DEVUSERERROR
+#define     WFS_CRD_DEVBUSY                     WFS_STAT_DEVBUSY
+#define     WFS_CRD_DEVFRAUDATTEMPT             WFS_STAT_DEVFRAUDATTEMPT
+#define     WFS_CRD_DEVPOTENTIALFRAUD           WFS_STAT_DEVPOTENTIALFRAUD
+
+/* values of WFSCRDSTATUS.fwDispenser */
+
+#define     WFS_CRD_DISPCUOK                    (0)
+#define     WFS_CRD_DISPCUSTATE                 (1)
+#define     WFS_CRD_DISPCUSTOP                  (2)
+#define     WFS_CRD_DISPCUUNKNOWN               (3)
+
+/* values of WFSCRDSTATUS.fwMedia,
+             WFSCRDRETAINCARD.fwPosition, and
+             WFSCRDMEDIADETECTED.wPosition */
+
+#define     WFS_CRD_MEDIAPRESENT                (1)
+#define     WFS_CRD_MEDIANOTPRESENT             (2)
+#define     WFS_CRD_MEDIAJAMMED                 (3)
+#define     WFS_CRD_MEDIANOTSUPP                (4)
+#define     WFS_CRD_MEDIAUNKNOWN                (5)
+#define     WFS_CRD_MEDIAEXITING                (6)
+#define     WFS_CRD_MEDIARETAINED               (7)
+
+/* values of WFSCRDSTATUS.fwTransport */
+
+#define     WFS_CRD_TPOK                        (0)
+#define     WFS_CRD_TPINOP                      (1)
+#define     WFS_CRD_TPUNKNOWN                   (2)
+#define     WFS_CRD_TPNOTSUPPORTED              (3)
+
+/* Size and max index of dwGuidLights array */
+
+#define     WFS_CRD_GUIDLIGHTS_SIZE             (32)
+#define     WFS_CRD_GUIDLIGHTS_MAX              (WFS_CRD_GUIDLIGHTS_SIZE - 1)
+
+/* Indices of WFSCRDSTATUS.dwGuidLights [...]
+              WFSCRDCAPS.dwGuidLights [...] */
+
+#define     WFS_CRD_GUIDANCE_CARDDISP           (0)
+
+/* Values of WFSCRDSTATUS.dwGuidLights [...]
+             WFSCRDCAPS.dwGuidLights [...] */
+
+#define     WFS_CRD_GUIDANCE_NOT_AVAILABLE      (0x00000000)
+#define     WFS_CRD_GUIDANCE_OFF                (0x00000001)
+#define     WFS_CRD_GUIDANCE_SLOW_FLASH         (0x00000004)
+#define     WFS_CRD_GUIDANCE_MEDIUM_FLASH       (0x00000008)
+#define     WFS_CRD_GUIDANCE_QUICK_FLASH        (0x00000010)
+#define     WFS_CRD_GUIDANCE_CONTINUOUS         (0x00000080)
+#define     WFS_CRD_GUIDANCE_RED                (0x00000100)
+#define     WFS_CRD_GUIDANCE_GREEN              (0x00000200)
+#define     WFS_CRD_GUIDANCE_YELLOW             (0x00000400)
+#define     WFS_CRD_GUIDANCE_BLUE               (0x00000800)
+#define     WFS_CRD_GUIDANCE_CYAN               (0x00001000)
+#define     WFS_CRD_GUIDANCE_MAGENTA            (0x00002000)
+#define     WFS_CRD_GUIDANCE_WHITE              (0x00004000)
+
+/* values of WFSCRDSTATUS.wDevicePosition
+             WFSCRDDEVICEPOSITION.wPosition */
+
+#define     WFS_CRD_DEVICEINPOSITION            (0)
+#define     WFS_CRD_DEVICENOTINPOSITION         (1)
+#define     WFS_CRD_DEVICEPOSUNKNOWN            (2)
+#define     WFS_CRD_DEVICEPOSNOTSUPP            (3)
+
+/*values of WFSCRDCAPS.fwDispenseTo */
+
+#define     WFS_CRD_DISPTO_CONSUMER             (0x0001)
+#define     WFS_CRD_DISPTO_TRANSPORT            (0x0002)
+
+/*values of WFSCRDCARDUNIT.usStatus */
+
+#define    WFS_CRD_STATCUOK                     (0)
+#define    WFS_CRD_STATCULOW                    (1)
+#define    WFS_CRD_STATCUEMPTY                  (2)
+#define    WFS_CRD_STATCUINOP                   (3)
+#define    WFS_CRD_STATCUMISSING                (4)
+#define    WFS_CRD_STATCUHIGH                   (5)
+#define    WFS_CRD_STATCUFULL                   (6)
+#define    WFS_CRD_STATCUUNKNOWN                (7)
+
+/*values of WFSCRDCARDUNIT.usType */
+
+#define    WFS_CRD_SUPPLYBIN                    (1)
+#define    WFS_CRD_RETAINBIN                    (2)
+
+/* values of WFSCRDSTATUS.fwShutter */
+
+#define     WFS_CRD_SHTCLOSED                   (0)
+#define     WFS_CRD_SHTOPEN                     (1)
+#define     WFS_CRD_SHTJAMMED                   (2)
+#define     WFS_CRD_SHTUNKNOWN                  (3)
+#define     WFS_CRD_SHTNOTSUPPORTED             (4)
+
+/* values of WFSCRDCAPS.fwPowerOnOption,
+             WFSCRDCAPS.fwPowerOffOption,
+             WFSCRDRESET.usAction  */
+
+#define     WFS_CRD_NOACTION                    (1)
+#define     WFS_CRD_EJECT                       (2)
+#define     WFS_CRD_RETAIN                      (3)
+#define     WFS_CRD_EJECTTHENRETAIN             (4)
+
+/*values of WFSCRDCUERROR.wFailure */
+
+#define WFS_CRD_CARDUNITEMPTY                   (1)
+#define WFS_CRD_CARDUNITERROR                   (2)
+#define WFS_CRD_CARDUNITINVALID                 (3)
+
+/* values of WFSCRDSTATUS.wAntiFraudModule */
+
+#define     WFS_CRD_AFMNOTSUPP                  (0)
+#define     WFS_CRD_AFMOK                       (1)
+#define     WFS_CRD_AFMINOP                     (2)
+#define     WFS_CRD_AFMDEVICEDETECTED           (3)
+#define     WFS_CRD_AFMUNKNOWN                  (4)
+
+/* XFS CRD Errors */
+
+#define WFS_ERR_CRD_MEDIAJAM                    (-(CRD_SERVICE_OFFSET + 0))
+#define WFS_ERR_CRD_NOMEDIA                     (-(CRD_SERVICE_OFFSET + 1))
+#define WFS_ERR_CRD_MEDIARETAINED               (-(CRD_SERVICE_OFFSET + 2))
+#define WFS_ERR_CRD_RETAINBINFULL               (-(CRD_SERVICE_OFFSET + 3))
+#define WFS_ERR_CRD_SHUTTERFAIL                 (-(CRD_SERVICE_OFFSET + 4))
+#define WFS_ERR_CRD_DEVICE_OCCUPIED             (-(CRD_SERVICE_OFFSET + 5))
+#define WFS_ERR_CRD_CARDUNITERROR               (-(CRD_SERVICE_OFFSET + 6))
+#define WFS_ERR_CRD_INVALIDCARDUNIT             (-(CRD_SERVICE_OFFSET + 7))
+#define WFS_ERR_CRD_INVALID_PORT                (-(CRD_SERVICE_OFFSET + 8))
+#define WFS_ERR_CRD_INVALIDRETAINBIN            (-(CRD_SERVICE_OFFSET + 9))
+#define WFS_ERR_CRD_POWERSAVETOOSHORT           (-(CRD_SERVICE_OFFSET + 10))
+#define WFS_ERR_CRD_POWERSAVEMEDIAPRESENT       (-(CRD_SERVICE_OFFSET + 11))
+
+/*=================================================================*/
+/* CRD Info Command Structures and variables */
+/*=================================================================*/
+
+typedef struct _wfs_crd_status
+{
+    WORD             fwDevice;
+    WORD             fwDispenser;
+    WORD             fwTransport;
+    WORD             fwMedia;
+    WORD             fwShutter;
+    LPSTR            lpszExtra;
+    DWORD            dwGuidLights[WFS_CRD_GUIDLIGHTS_SIZE];
+    WORD             wDevicePosition;
+    USHORT           usPowerSaveRecoveryTime;
+    WORD             wAntiFraudModule;
+} WFSCRDSTATUS, *LPWFSCRDSTATUS;
+
+typedef struct _wfs_crd_caps
+{
+    WORD             wClass;
+    BOOL             bCompound;
+    WORD             fwPowerOnOption;
+    WORD             fwPowerOffOption;
+    BOOL             bCardTakenSensor;
+    WORD             fwDispenseTo;
+    LPSTR            lpszExtra;
+    DWORD            dwGuidLights[WFS_CRD_GUIDLIGHTS_SIZE];
+    BOOL             bPowerSaveControl;
+    BOOL             bAntiFraudModule;
+
+} WFSCRDCAPS, *LPWFSCRDCAPS;
+
+typedef struct _wfs_crd_cardunit
+{
+    USHORT           usNumber;
+    LPSTR            lpszCardName;
+    USHORT           usType;
+    ULONG            ulInitialCount;
+    ULONG            ulCount;
+    ULONG            ulRetainCount;
+    ULONG            ulThreshold;
+    USHORT           usStatus;
+    BOOL             bHardwareSensor;
+} WFSCRDCARDUNIT, *LPWFSCRDCARDUNIT;
+
+typedef struct _wfs_crd_cu_info
+{
+    USHORT           usCount;
+    LPWFSCRDCARDUNIT *lppList;
+} WFSCRDCUINFO, *LPWFSCRDCUINFO;
+
+/*=================================================================*/
+/* CRD Execute Command Structures */
+/*=================================================================*/
+
+typedef struct _wfs_crd_dispense
+{
+    USHORT           usNumber;
+    BOOL             bPresent;
+} WFSCRDDISPENSE, *LPWFSCRDDISPENSE;
+
+typedef struct _wfs_crd_retain_card
+{
+    USHORT           usNumber;
+} WFSCRDRETAINCARD, *LPWFSCRDRETAINCARD;
+
+typedef struct _wfs_crd_reset
+{
+    USHORT           usAction;
+} WFSCRDRESET, *LPWFSCRDRESET;
+
+typedef struct _wfs_crd_set_guidlight
+{
+    WORD             wGuidLight;
+    DWORD            dwCommand;
+} WFSCRDSETGUIDLIGHT, *LPWFSCRDSETGUIDLIGHT;
+
+typedef struct _wfs_crd_power_save_control
+{
+    USHORT           usMaxPowerSaveRecoveryTime;
+} WFSCRDPOWERSAVECONTROL, *LPWFSCRDPOWERSAVECONTROL;
+
+/*=================================================================*/
+/* CRD Message Structures */
+/*=================================================================*/
+
+typedef struct _wfs_crd_media_detected
+{
+    WORD             wPosition;
+    USHORT           usNumber;
+} WFSCRDMEDIADETECTED, *LPWFSCRDMEDIADETECTED;
+
+typedef struct _wfs_crd_cu_error
+{
+    WORD             wFailure;
+    LPWFSCRDCARDUNIT lpCardUnit;
+} WFSCRDCUERROR, *LPWFSCRDCUERROR;
+
+typedef struct _wfs_crd_device_position
+{
+    WORD             wPosition;
+} WFSCRDDEVICEPOSITION, *LPWFSCRDDEVICEPOSITION;
+
+typedef struct _wfs_crd_power_save_change
+{
+    USHORT           usPowerSaveRecoveryTime;
+} WFSCRDPOWERSAVECHANGE, *LPWFSCRDPOWERSAVECHANGE;
+
+/*   restore alignment   */
+#pragma pack(pop)
+
+#ifdef __cplusplus
+}       /*extern "C"*/
+#endif
+
+#endif  /* __INC_XFSCRD__H */

--- a/cen/320/xfsdep.h
+++ b/cen/320/xfsdep.h
@@ -1,0 +1,329 @@
+/******************************************************************************
+*                                                                             *
+* xfsdep.h   XFS - Depository (DEP) definitions                               *
+*                                                                             *
+*             Version 3.20  (March 02 2011)                                   *
+*                                                                             *
+*******************************************************************************/
+
+#ifndef __INC_XFSDEP__H
+#define __INC_XFSDEP__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "xfsapi.h"
+
+/* be aware of alignment */
+#pragma pack(push,1)
+
+/* values of WFSDEPCAPS.wClass */
+
+#define     WFS_SERVICE_CLASS_DEP               (6)
+#define     WFS_SERVICE_CLASS_VERSION_DEP       (0x1403) /* Version 3.20 */
+#define     WFS_SERVICE_CLASS_NAME_DEP          "DEP"
+
+#define     DEP_SERVICE_OFFSET                  (WFS_SERVICE_CLASS_DEP * 100)
+
+/* DEP Info Commands */
+
+#define     WFS_INF_DEP_STATUS                  (DEP_SERVICE_OFFSET + 1)
+#define     WFS_INF_DEP_CAPABILITIES            (DEP_SERVICE_OFFSET + 2)
+
+/* DEP Execute Commands */
+
+#define     WFS_CMD_DEP_ENTRY                   (DEP_SERVICE_OFFSET + 1)
+#define     WFS_CMD_DEP_DISPENSE                (DEP_SERVICE_OFFSET + 2)
+#define     WFS_CMD_DEP_RETRACT                 (DEP_SERVICE_OFFSET + 3)
+#define     WFS_CMD_DEP_RESET_COUNT             (DEP_SERVICE_OFFSET + 5)
+#define     WFS_CMD_DEP_RESET                   (DEP_SERVICE_OFFSET + 6)
+#define     WFS_CMD_DEP_SET_GUIDANCE_LIGHT      (DEP_SERVICE_OFFSET + 7)
+#define     WFS_CMD_DEP_SUPPLY_REPLENISH        (DEP_SERVICE_OFFSET + 8)
+#define     WFS_CMD_DEP_POWER_SAVE_CONTROL      (DEP_SERVICE_OFFSET + 9)
+
+/* DEP Messages */
+
+#define     WFS_SRVE_DEP_ENVTAKEN               (DEP_SERVICE_OFFSET + 1)
+#define     WFS_EXEE_DEP_ENVDEPOSITED           (DEP_SERVICE_OFFSET + 2)
+#define     WFS_EXEE_DEP_DEPOSITERROR           (DEP_SERVICE_OFFSET + 3)
+#define     WFS_USRE_DEP_DEPTHRESHOLD           (DEP_SERVICE_OFFSET + 4)
+#define     WFS_USRE_DEP_TONERTHRESHOLD         (DEP_SERVICE_OFFSET + 5)
+#define     WFS_USRE_DEP_ENVTHRESHOLD           (DEP_SERVICE_OFFSET + 6)
+#define     WFS_SRVE_DEP_CONTINSERTED           (DEP_SERVICE_OFFSET + 7)
+#define     WFS_SRVE_DEP_CONTREMOVED            (DEP_SERVICE_OFFSET + 8)
+#define     WFS_SRVE_DEP_ENVINSERTED            (DEP_SERVICE_OFFSET + 9)
+#define     WFS_SRVE_DEP_MEDIADETECTED          (DEP_SERVICE_OFFSET + 10)
+#define     WFS_EXEE_DEP_INSERTDEPOSIT          (DEP_SERVICE_OFFSET + 11)
+#define     WFS_SRVE_DEP_DEVICEPOSITION         (DEP_SERVICE_OFFSET + 12)
+#define     WFS_SRVE_DEP_POWER_SAVE_CHANGE      (DEP_SERVICE_OFFSET + 13)
+
+/* values of WFSDEPSTATUS.fwDevice */
+
+#define     WFS_DEP_DEVONLINE                   WFS_STAT_DEVONLINE
+#define     WFS_DEP_DEVOFFLINE                  WFS_STAT_DEVOFFLINE
+#define     WFS_DEP_DEVPOWEROFF                 WFS_STAT_DEVPOWEROFF
+#define     WFS_DEP_DEVBUSY                     WFS_STAT_DEVBUSY
+#define     WFS_DEP_DEVNODEVICE                 WFS_STAT_DEVNODEVICE
+#define     WFS_DEP_DEVHWERROR                  WFS_STAT_DEVHWERROR
+#define     WFS_DEP_DEVUSERERROR                WFS_STAT_DEVUSERERROR
+#define     WFS_DEP_DEVFRAUDATTEMPT             WFS_STAT_DEVFRAUDATTEMPT
+#define     WFS_DEP_DEVPOTENTIALFRAUD           WFS_STAT_DEVPOTENTIALFRAUD
+
+/* values of WFSDEPSTATUS.fwDepContainer, fwDepTransport */
+
+#define     WFS_DEP_DEPOK                       (0)
+#define     WFS_DEP_DEPHIGH                     (1)
+#define     WFS_DEP_DEPFULL                     (2)
+#define     WFS_DEP_DEPINOP                     (3)
+#define     WFS_DEP_DEPMISSING                  (4)
+#define     WFS_DEP_DEPUNKNOWN                  (5)
+#define     WFS_DEP_DEPNOTSUPP                  (6)
+
+/* values of WFSDEPSTATUS.fwEnvSupply, fwEnvDispenser */
+
+#define     WFS_DEP_ENVOK                       (0)
+#define     WFS_DEP_ENVLOW                      (1)
+#define     WFS_DEP_ENVEMPTY                    (2)
+#define     WFS_DEP_ENVINOP                     (3)
+#define     WFS_DEP_ENVMISSING                  (4)
+#define     WFS_DEP_ENVUNKNOWN                  (5)
+#define     WFS_DEP_ENVNOTSUPP                  (6)
+#define     WFS_DEP_ENVUNLOCKED                 (7)
+
+/* values of WFSDEPSTATUS.fwPrinter */
+
+#define     WFS_DEP_PTROK                       (0)
+#define     WFS_DEP_PTRINOP                     (1)
+#define     WFS_DEP_PTRUNKNOWN                  (2)
+#define     WFS_DEP_PTRNOTSUPP                  (3)
+
+/* values of WFSDEPSTATUS.fwToner */
+
+#define     WFS_DEP_TONERFULL                   (0)
+#define     WFS_DEP_TONERLOW                    (1)
+#define     WFS_DEP_TONEROUT                    (2)
+#define     WFS_DEP_TONERUNKNOWN                (3)
+#define     WFS_DEP_TONERNOTSUPP                (4)
+
+/* values of WFSDEPSTATUS.fwShutter */
+
+#define     WFS_DEP_SHTCLOSED                   (0)
+#define     WFS_DEP_SHTOPEN                     (1)
+#define     WFS_DEP_SHTJAMMED                   (2)
+#define     WFS_DEP_SHTUNKNOWN                  (3)
+#define     WFS_DEP_SHTNOTSUPP                  (4)
+
+/* Size and max index of dwGuidLights array */
+
+#define     WFS_DEP_GUIDLIGHTS_SIZE             (32)
+#define     WFS_DEP_GUIDLIGHTS_MAX              (WFS_DEP_GUIDLIGHTS_SIZE - 1)
+
+/* Indices of WFSDEPSTATUS.dwGuidLights [...]
+              WFSDEPCAPS.dwGuidLights [...]
+*/
+
+#define     WFS_DEP_GUIDANCE_ENVDEPOSITORY      (0)
+#define     WFS_DEP_GUIDANCE_ENVDISPENSER       (1)
+
+/* Values of WFSDEPSTATUS.dwGuidLights [...]
+             WFSDEPCAPS.dwGuidLights [...] */
+
+#define     WFS_DEP_GUIDANCE_NOT_AVAILABLE      (0x00000000)
+#define     WFS_DEP_GUIDANCE_OFF                (0x00000001)
+#define     WFS_DEP_GUIDANCE_SLOW_FLASH         (0x00000004)
+#define     WFS_DEP_GUIDANCE_MEDIUM_FLASH       (0x00000008)
+#define     WFS_DEP_GUIDANCE_QUICK_FLASH        (0x00000010)
+#define     WFS_DEP_GUIDANCE_CONTINUOUS         (0x00000080)
+#define     WFS_DEP_GUIDANCE_RED                (0x00000100)
+#define     WFS_DEP_GUIDANCE_GREEN              (0x00000200)
+#define     WFS_DEP_GUIDANCE_YELLOW             (0x00000400)
+#define     WFS_DEP_GUIDANCE_BLUE               (0x00000800)
+#define     WFS_DEP_GUIDANCE_CYAN               (0x00001000)
+#define     WFS_DEP_GUIDANCE_MAGENTA            (0x00002000)
+#define     WFS_DEP_GUIDANCE_WHITE              (0x00004000)
+
+/* values of WFSDEPSTATUS.fwDepositLocation */
+
+#define WFS_DEP_DEPLOCNOTSUPP                   (0)
+#define WFS_DEP_DEPLOCUNKNOWN                   (1)
+#define WFS_DEP_DEPLOCCONTAINER                 (2)
+#define WFS_DEP_DEPLOCTRANSPORT                 (3)
+#define WFS_DEP_DEPLOCPRINTER                   (4)
+#define WFS_DEP_DEPLOCSHUTTER                   (5)
+#define WFS_DEP_DEPLOCNONE                      (6)
+#define WFS_DEP_DEPLOCREMOVED                   (7)
+
+/* values of WFSDEPSTATUS.wDevicePosition
+             WFSDEPDEVICEPOSITION.wPosition */
+
+#define     WFS_DEP_DEVICEINPOSITION            (0)
+#define     WFS_DEP_DEVICENOTINPOSITION         (1)
+#define     WFS_DEP_DEVICEPOSUNKNOWN            (2)
+#define     WFS_DEP_DEVICEPOSNOTSUPP            (3)
+
+/* values of WFSDEPCAPS.fwType */
+
+#define     WFS_DEP_TYPEENVELOPE                (0x0001)
+#define     WFS_DEP_TYPEBAGDROP                 (0x0002)
+
+/* values of WFSDEPCAPS.fwEnvSupply */
+
+#define     WFS_DEP_ENVMOTORIZED                (1)
+#define     WFS_DEP_ENVMANUAL                   (2)
+#define     WFS_DEP_ENVNONE                     (3)
+
+/* values of WFSDEPCAPS.fwRetractEnvelope */
+
+#define     WFS_DEP_NORETRACT                   (1)
+#define     WFS_DEP_RETRACTDEP                  (2)
+#define     WFS_DEP_RETRACTDISP                 (3)
+
+/* values of WFSDEPCAPS.fwCharSupport, WFSDEPENVELOPE.fwCharSupport */
+
+#define     WFS_DEP_ASCII                       (0x0001)
+#define     WFS_DEP_UNICODE                     (0x0002)
+
+/* values of dwDepMediaControl  */
+
+#define     WFS_DEP_CTRLEJECT                   (0x0001)
+#define     WFS_DEP_CTRLRETRACT                 (0x0002)
+
+
+/* values of WFSDEPMEDIADETECTED.wDispenseMedia, wDepositMedia */
+
+#define     WFS_DEP_NOMEDIA                     (1)
+#define     WFS_DEP_MEDIARETRACTED              (2)
+#define     WFS_DEP_MEDIADISPENSER              (3)
+#define     WFS_DEP_MEDIAEJECTED                (4)
+#define     WFS_DEP_MEDIAJAMMED                 (5)
+#define     WFS_DEP_MEDIAUNKNOWN                (6)
+
+/* values of WFSDEPSUPPLYREPLEN.fwSupplyReplen */
+
+#define     WFS_DEP_REPLEN_ENV                  (0x0001)
+#define     WFS_DEP_REPLEN_TONER                (0x0002)
+
+/* values of WFSDEPSTATUS.wAntiFraudModule */
+
+#define     WFS_DEP_AFMNOTSUPP                  (0)
+#define     WFS_DEP_AFMOK                       (1)
+#define     WFS_DEP_AFMINOP                     (2)
+#define     WFS_DEP_AFMDEVICEDETECTED           (3)
+#define     WFS_DEP_AFMUNKNOWN                  (4)
+
+#define WFS_ERR_DEP_DEPFULL                     (-(DEP_SERVICE_OFFSET + 0))
+#define WFS_ERR_DEP_DEPJAMMED                   (-(DEP_SERVICE_OFFSET + 1))
+#define WFS_ERR_DEP_ENVEMPTY                    (-(DEP_SERVICE_OFFSET + 2))
+#define WFS_ERR_DEP_ENVJAMMED                   (-(DEP_SERVICE_OFFSET + 3))
+#define WFS_ERR_DEP_ENVSIZE                     (-(DEP_SERVICE_OFFSET + 4))
+#define WFS_ERR_DEP_NOENV                       (-(DEP_SERVICE_OFFSET + 5))
+#define WFS_ERR_DEP_PTRFAIL                     (-(DEP_SERVICE_OFFSET + 6))
+#define WFS_ERR_DEP_SHTNOTCLOSED                (-(DEP_SERVICE_OFFSET + 7))
+#define WFS_ERR_DEP_SHTNOTOPENED                (-(DEP_SERVICE_OFFSET + 8))
+#define WFS_ERR_DEP_CONTMISSING                 (-(DEP_SERVICE_OFFSET + 9))
+#define WFS_ERR_DEP_DEPUNKNOWN                  (-(DEP_SERVICE_OFFSET + 10))
+#define WFS_ERR_DEP_CHARSETNOTSUPP              (-(DEP_SERVICE_OFFSET + 11))
+#define WFS_ERR_DEP_TONEROUT                    (-(DEP_SERVICE_OFFSET + 12))
+#define WFS_ERR_DEP_INVALID_PORT                (-(DEP_SERVICE_OFFSET + 13))
+#define WFS_ERR_DEP_POWERSAVETOOSHORT           (-(DEP_SERVICE_OFFSET + 14))
+#define WFS_ERR_DEP_POWERSAVEMEDIAPRESENT       (-(DEP_SERVICE_OFFSET + 15))
+
+/*====================================================================*/
+/* DEP Info Command Structures and variables */
+/*====================================================================*/
+
+typedef struct _wfs_dep_status
+{
+     WORD            fwDevice;
+     WORD            fwDepContainer;
+     WORD            fwDepTransport;
+     WORD            fwEnvSupply;
+     WORD            fwEnvDispenser;
+     WORD            fwPrinter;
+     WORD            fwToner;
+     WORD            fwShutter;
+     WORD            wNumOfDeposits;
+     LPSTR           lpszExtra;
+     DWORD           dwGuidLights[WFS_DEP_GUIDLIGHTS_SIZE];
+     WORD            fwDepositLocation;
+     WORD            wDevicePosition;
+     USHORT          usPowerSaveRecoveryTime;
+     WORD            wAntiFraudModule;
+} WFSDEPSTATUS, *LPWFSDEPSTATUS;
+
+typedef struct _wfs_dep_caps
+{
+     WORD            wClass;
+     WORD            fwType;
+     WORD            fwEnvSupply;
+     BOOL            bDepTransport;
+     BOOL            bPrinter;
+     BOOL            bToner;
+     BOOL            bShutter;
+     BOOL            bPrintOnRetracts;
+     WORD            fwRetractEnvelope;
+     WORD            wMaxNumChars;
+     WORD            fwCharSupport;
+     LPSTR           lpszExtra;
+     DWORD           dwGuidLights[WFS_DEP_GUIDLIGHTS_SIZE];
+     BOOL            bPowerSaveControl;
+     BOOL            bAntiFraudModule;
+
+} WFSDEPCAPS, *LPWFSDEPCAPS;
+
+/*====================================================================*/
+/* DEP Execute Command Structures */
+/*====================================================================*/
+
+typedef struct _wfs_dep_envelope
+{
+     LPSTR           lpszPrintData;
+     LPWSTR          lpszUNICODEPrintData;
+} WFSDEPENVELOPE, *LPWFSDEPENVELOPE;
+
+typedef struct _wfs_dep_set_guidlight
+{
+     WORD            wGuidLight;
+     DWORD           dwCommand;
+} WFSDEPSETGUIDLIGHT, *LPWFSDEPSETGUIDLIGHT;
+
+typedef struct _wfs_dep_supply_replen
+{
+     WORD            fwSupplyReplen;
+} WFSDEPSUPPLYREPLEN, *LPWFSDEPSUPPLYREPLEN;
+
+typedef struct _wfs_dep_power_save_control
+{
+     USHORT          usMaxPowerSaveRecoveryTime;
+} WFSDEPPOWERSAVECONTROL, *LPWFSDEPPOWERSAVECONTROL;
+
+/*====================================================================*/
+/* DEP Message Structures */
+/*====================================================================*/
+
+typedef struct _wfs_dep_media_detected
+{
+     WORD            wDispenseMedia;
+     WORD            wDepositMedia;
+} WFSDEPMEDIADETECTED, *LPWFSDEPMEDIADETECTED;
+
+typedef struct _wfs_dep_device_position
+{
+     WORD            wPosition;
+} WFSDEPDEVICEPOSITION, *LPWFSDEPDEVICEPOSITION;
+
+typedef struct _wfs_dep_power_save_change
+{
+     USHORT          usPowerSaveRecoveryTime;
+} WFSDEPPOWERSAVECHANGE, *LPWFSDEPPOWERSAVECHANGE;
+
+
+/* restore alignment */
+#pragma pack(pop)
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /* __INC_XFSDEP__H */

--- a/cen/320/xfsipm.h
+++ b/cen/320/xfsipm.h
@@ -1,0 +1,947 @@
+/******************************************************************************
+*                                                                             *
+* xfsipm.h    XFS - Item Processing Module (IPM) definitions                  *
+*                                                                             *
+*             Version 3.20  (March 02 2011)                                   *
+*                                                                             *
+******************************************************************************/
+
+#ifndef __INC_XFSIPM__H
+#define  __INC_XFSIPM__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "xfsapi.h"
+
+/*   be aware of alignment   */
+#pragma pack(push,1)
+
+/* Value of WFSIPMCAPS.wClass */
+
+#define     WFS_SERVICE_CLASS_IPM               (16)
+#define     WFS_SERVICE_CLASS_VERSION_IPM       (0x1403) /* Version 3.20 */
+#define     WFS_SERVICE_CLASS_NAME_IPM          "IPM"
+
+#define     IPM_SERVICE_OFFSET                  (WFS_SERVICE_CLASS_IPM * 100)
+
+/* IPM Info Commands */
+
+#define     WFS_INF_IPM_STATUS                  (IPM_SERVICE_OFFSET + 1)
+#define     WFS_INF_IPM_CAPABILITIES            (IPM_SERVICE_OFFSET + 2)
+#define     WFS_INF_IPM_CODELINE_MAPPING        (IPM_SERVICE_OFFSET + 3)
+#define     WFS_INF_IPM_MEDIA_BIN_INFO          (IPM_SERVICE_OFFSET + 4)
+#define     WFS_INF_IPM_TRANSACTION_STATUS      (IPM_SERVICE_OFFSET + 5)
+
+/* IPM Execute Commands */
+
+#define     WFS_CMD_IPM_MEDIA_IN                (IPM_SERVICE_OFFSET + 1)
+#define     WFS_CMD_IPM_MEDIA_IN_END            (IPM_SERVICE_OFFSET + 2)
+#define     WFS_CMD_IPM_MEDIA_IN_ROLLBACK       (IPM_SERVICE_OFFSET + 3)
+#define     WFS_CMD_IPM_READ_IMAGE              (IPM_SERVICE_OFFSET + 4)
+#define     WFS_CMD_IPM_SET_DESTINATION         (IPM_SERVICE_OFFSET + 5)
+#define     WFS_CMD_IPM_PRESENT_MEDIA           (IPM_SERVICE_OFFSET + 6)
+#define     WFS_CMD_IPM_RETRACT_MEDIA           (IPM_SERVICE_OFFSET + 7)
+#define     WFS_CMD_IPM_PRINT_TEXT              (IPM_SERVICE_OFFSET + 8)
+#define     WFS_CMD_IPM_SET_MEDIA_BIN_INFO      (IPM_SERVICE_OFFSET + 9)
+#define     WFS_CMD_IPM_RESET                   (IPM_SERVICE_OFFSET + 10)
+#define     WFS_CMD_IPM_SET_GUIDANCE_LIGHT      (IPM_SERVICE_OFFSET + 11)
+#define     WFS_CMD_IPM_GET_NEXT_ITEM           (IPM_SERVICE_OFFSET + 12)
+#define     WFS_CMD_IPM_ACTION_ITEM             (IPM_SERVICE_OFFSET + 13)
+#define     WFS_CMD_IPM_EXPEL_MEDIA             (IPM_SERVICE_OFFSET + 14)
+#define     WFS_CMD_IPM_GET_IMAGE_AFTER_PRINT   (IPM_SERVICE_OFFSET + 15)
+#define     WFS_CMD_IPM_ACCEPT_ITEM             (IPM_SERVICE_OFFSET + 16)
+#define     WFS_CMD_IPM_SUPPLY_REPLENISH        (IPM_SERVICE_OFFSET + 17)
+#define     WFS_CMD_IPM_POWER_SAVE_CONTROL      (IPM_SERVICE_OFFSET + 18)
+#define     WFS_CMD_IPM_SET_MODE                (IPM_SERVICE_OFFSET + 19)
+
+/* IPM Messages */
+
+#define     WFS_EXEE_IPM_NOMEDIA                (IPM_SERVICE_OFFSET + 1)
+#define     WFS_EXEE_IPM_MEDIAINSERTED          (IPM_SERVICE_OFFSET + 2)
+#define     WFS_USRE_IPM_MEDIABINTHRESHOLD      (IPM_SERVICE_OFFSET + 3)
+#define     WFS_SRVE_IPM_MEDIABININFOCHANGED    (IPM_SERVICE_OFFSET + 4)
+#define     WFS_EXEE_IPM_MEDIABINERROR          (IPM_SERVICE_OFFSET + 5)
+#define     WFS_SRVE_IPM_MEDIATAKEN             (IPM_SERVICE_OFFSET + 6)
+#define     WFS_USRE_IPM_TONERTHRESHOLD         (IPM_SERVICE_OFFSET + 7)
+#define     WFS_USRE_IPM_SCANNERTHRESHOLD       (IPM_SERVICE_OFFSET + 8)
+#define     WFS_USRE_IPM_INKTHRESHOLD           (IPM_SERVICE_OFFSET + 9)
+#define     WFS_SRVE_IPM_MEDIADETECTED          (IPM_SERVICE_OFFSET + 10)
+#define     WFS_EXEE_IPM_MEDIAPRESENTED         (IPM_SERVICE_OFFSET + 11)
+#define     WFS_EXEE_IPM_MEDIAREFUSED           (IPM_SERVICE_OFFSET + 12)
+#define     WFS_EXEE_IPM_MEDIADATA              (IPM_SERVICE_OFFSET + 13)
+#define     WFS_USRE_IPM_MICRTHRESHOLD          (IPM_SERVICE_OFFSET + 14)
+#define     WFS_EXEE_IPM_MEDIAREJECTED          (IPM_SERVICE_OFFSET + 15)
+#define     WFS_SRVE_IPM_DEVICEPOSITION         (IPM_SERVICE_OFFSET + 16)
+#define     WFS_SRVE_IPM_POWER_SAVE_CHANGE      (IPM_SERVICE_OFFSET + 17)
+
+/* Values of WFSIPMSTATUS.fwDevice */
+
+#define     WFS_IPM_DEVONLINE                   WFS_STAT_DEVONLINE
+#define     WFS_IPM_DEVOFFLINE                  WFS_STAT_DEVOFFLINE
+#define     WFS_IPM_DEVPOWEROFF                 WFS_STAT_DEVPOWEROFF
+#define     WFS_IPM_DEVNODEVICE                 WFS_STAT_DEVNODEVICE
+#define     WFS_IPM_DEVHWERROR                  WFS_STAT_DEVHWERROR
+#define     WFS_IPM_DEVUSERERROR                WFS_STAT_DEVUSERERROR
+#define     WFS_IPM_DEVBUSY                     WFS_STAT_DEVBUSY
+#define     WFS_IPM_DEVFRAUDATTEMPT             WFS_STAT_DEVFRAUDATTEMPT
+#define     WFS_IPM_DEVPOTENTIALFRAUD           WFS_STAT_DEVPOTENTIALFRAUD
+
+/* Values of WFSIPMSTATUS.wAcceptor */
+
+#define     WFS_IPM_ACCBINOK                    (0)
+#define     WFS_IPM_ACCBINSTATE                 (1)
+#define     WFS_IPM_ACCBINSTOP                  (2)
+#define     WFS_IPM_ACCBINUNKNOWN               (3)
+
+/* Values of WFSIPMSTATUS.wMedia and
+             WFSIPMMEDIADETECTED.wPosition */
+
+#define     WFS_IPM_MEDIAPRESENT                (0)
+#define     WFS_IPM_MEDIANOTPRESENT             (1)
+#define     WFS_IPM_MEDIAJAMMED                 (2)
+#define     WFS_IPM_MEDIANOTSUPP                (3)
+#define     WFS_IPM_MEDIAUNKNOWN                (4)
+#define     WFS_IPM_MEDIAPOSITION               (5)
+#define     WFS_IPM_MEDIARETRACTED              (6)
+#define     WFS_IPM_MEDIARETURNED               (7)
+
+/* Values of WFSIPMSTATUS.wToner and
+             WFSIPMTHRESHOLD.wThreshold */
+
+#define     WFS_IPM_TONERFULL                   (0)
+#define     WFS_IPM_TONERLOW                    (1)
+#define     WFS_IPM_TONEROUT                    (2)
+#define     WFS_IPM_TONERNOTSUPP                (3)
+#define     WFS_IPM_TONERUNKNOWN                (4)
+
+/* Values of WFSIPMSTATUS.wInk and
+             WFSIPMTHRESHOLD.wThreshold */
+
+#define     WFS_IPM_INKFULL                     (0)
+#define     WFS_IPM_INKLOW                      (1)
+#define     WFS_IPM_INKOUT                      (2)
+#define     WFS_IPM_INKNOTSUPP                  (3)
+#define     WFS_IPM_INKUNKNOWN                  (4)
+
+/* Values of WFSIPMSTATUS.wFrontImageScanner,
+             WFSIPMSTATUS.wBackImageScanner and
+             WFSIPMSCANNERTHRESHOLD.wThreshold */
+
+#define     WFS_IPM_SCANNEROK                   (0)
+#define     WFS_IPM_SCANNERFADING               (1)
+#define     WFS_IPM_SCANNERINOP                 (2)
+#define     WFS_IPM_SCANNERNOTSUPP              (3)
+#define     WFS_IPM_SCANNERUNKNOWN              (4)
+
+/* Values of WFSIPMSTATUS.wMICRReader and
+             WFSIPMTHRESHOLD.wThreshold */
+
+#define     WFS_IPM_MICROK                      (0)
+#define     WFS_IPM_MICRFADING                  (1)
+#define     WFS_IPM_MICRINOP                    (2)
+#define     WFS_IPM_MICRNOTSUPP                 (3)
+#define     WFS_IPM_MICRUNKNOWN                 (4)
+
+/* Values of WFSIPMSTATUS.wStacker  */
+
+#define     WFS_IPM_STACKEREMPTY                (0)
+#define     WFS_IPM_STACKERNOTEMPTY             (1)
+#define     WFS_IPM_STACKERFULL                 (2)
+#define     WFS_IPM_STACKERINOP                 (3)
+#define     WFS_IPM_STACKERUNKNOWN              (4)
+#define     WFS_IPM_STACKERNOTSUPP              (5)
+
+/* Values of WFSIPMSTATUS.wReBuncher       */
+
+#define     WFS_IPM_REBUNCHEREMPTY              (0)
+#define     WFS_IPM_REBUNCHERNOTEMPTY           (1)
+#define     WFS_IPM_REBUNCHERFULL               (2)
+#define     WFS_IPM_REBUNCHERINOP               (3)
+#define     WFS_IPM_REBUNCHERUNKNOWN            (4)
+#define     WFS_IPM_REBUNCHERNOTSUPP            (5)
+
+/* Values of WFSIPMSTATUS.wMediaFeeder and
+             WFSIPMMEDIAIN.wMediaFeeder*/
+
+#define     WFS_IPM_FEEDEREMPTY                 (0)
+#define     WFS_IPM_FEEDERNOTEMPTY              (1)
+#define     WFS_IPM_FEEDERINOP                  (2)
+#define     WFS_IPM_FEEDERUNKNOWN               (3)
+#define     WFS_IPM_FEEDERNOTSUPP               (4)
+
+/* Values of WFSIPMSTATUS.wDevicePosition and
+             WFSIPMDEVICEPOSITION.wPosition */
+
+#define     WFS_IPM_DEVICEINPOSITION            (0)
+#define     WFS_IPM_DEVICENOTINPOSITION         (1)
+#define     WFS_IPM_DEVICEPOSUNKNOWN            (2)
+#define     WFS_IPM_DEVICEPOSNOTSUPP            (3)
+
+/* Values of WFSIPMTRANSSTATUS.usMediaOnStacker,
+             WFSIPMTRANSSTATUS.usLastMediaInTotal,
+             WFSIPMTRANSSTATUS.usLastMediaAddedToStacker,
+             WFSIPMTRANSSTATUS.usTotalItems,
+             WFSIPMTRANSSTATUS.usTotalItemsRefused,
+             WFSIPMTRANSSTATUS.usTotalBunchesRefused,
+             WFSIPMMEDIAIN.usMediaOnStacker,
+             WFSIPMMEDIAIN.usLastMedia,
+             WFSIPMMEDIAIN.usLastMediaOnStacker and
+             WFSIPMRETRACTMEDIAOUT.usMedia */
+
+#define     WFS_IPM_MEDIANUMBERUNKNOWN          (0xFFFF)
+
+/* Indices for WFSIPMSTATUS.lppPositions and
+               WFSIPMCAPS.lppPositions,
+   Values of WFSIPMPOSITION.wPosition and
+             WFSIPMMEDIAPRESENTED.wPosition */
+
+#define     WFS_IPM_POSINPUT                    (0)
+#define     WFS_IPM_POSOUTPUT                   (1)
+#define     WFS_IPM_POSREFUSED                  (2)
+
+/* Values of WFSIPMPOS.wShutter */
+
+#define     WFS_IPM_SHTCLOSED                   (0)
+#define     WFS_IPM_SHTOPEN                     (1)
+#define     WFS_IPM_SHTJAMMED                   (2)
+#define     WFS_IPM_SHTUNKNOWN                  (3)
+#define     WFS_IPM_SHTNOTSUPPORTED             (4)
+
+/* Values of WFSIPMCAPS.wMixedMode */
+
+#define     WFS_IPM_MIXEDMEDIANOTSUPP           (0)
+#define     WFS_IPM_CIMMIXEDMEDIA               (1)
+
+/* Values of WFSIPMSETMODE.wMixedMode and
+             WFSIPMSTATUS.wMixedMode */
+
+#define     WFS_IPM_MIXEDMEDIANOTACTIVE         (0)
+
+/* Values of WFSIPMPOS.wPositionStatus */
+
+#define     WFS_IPM_PSEMPTY                     (0)
+#define     WFS_IPM_PSNOTEMPTY                  (1)
+#define     WFS_IPM_PSUNKNOWN                   (2)
+#define     WFS_IPM_PSNOTSUPPORTED              (3)
+
+/* Values of WFSIPMPOS.wTransport */
+
+#define     WFS_IPM_TPOK                        (0)
+#define     WFS_IPM_TPINOP                      (1)
+#define     WFS_IPM_TPUNKNOWN                   (2)
+#define     WFS_IPM_TPNOTSUPPORTED              (3)
+
+/* Values of WFSIPMPOS.wTransportMediaStatus */
+
+#define     WFS_IPM_TPMEDIAEMPTY                (0)
+#define     WFS_IPM_TPMEDIANOTEMPTY             (1)
+#define     WFS_IPM_TPMEDIAUNKNOWN              (2)
+#define     WFS_IPM_TPMEDIANOTSUPPORTED         (3)
+
+/* Size and max index of dwGuidLights array */
+
+#define     WFS_IPM_GUIDLIGHTS_SIZE             (32)
+#define     WFS_IPM_GUIDLIGHTS_MAX              (WFS_IPM_GUIDLIGHTS_SIZE - 1)
+
+/* Indices of WFSIPMSTATUS.dwGuidLights [...] and
+              WFSIPMCAPS.dwGuidLights [...] and
+   Values of WFSIPMSETGUIDLIGHT.wGuidLight */
+
+#define     WFS_IPM_GUIDANCE_MEDIAIN            (0)
+#define     WFS_IPM_GUIDANCE_MEDIAOUT           (1)
+#define     WFS_IPM_GUIDANCE_MEDIAREFUSED       (2)
+
+/* Values of WFSIPMSTATUS.dwGuidLights [...],
+             WFSIPMCAPS.dwGuidLights [...] and
+             WFSIPMSETGUIDLIGHT.dwCommand */
+
+#define     WFS_IPM_GUIDANCE_NOT_AVAILABLE      (0x00000000)
+#define     WFS_IPM_GUIDANCE_OFF                (0x00000001)
+#define     WFS_IPM_GUIDANCE_SLOW_FLASH         (0x00000004)
+#define     WFS_IPM_GUIDANCE_MEDIUM_FLASH       (0x00000008)
+#define     WFS_IPM_GUIDANCE_QUICK_FLASH        (0x00000010)
+#define     WFS_IPM_GUIDANCE_CONTINUOUS         (0x00000080)
+#define     WFS_IPM_GUIDANCE_RED                (0x00000100)
+#define     WFS_IPM_GUIDANCE_GREEN              (0x00000200)
+#define     WFS_IPM_GUIDANCE_YELLOW             (0x00000400)
+#define     WFS_IPM_GUIDANCE_BLUE               (0x00000800)
+#define     WFS_IPM_GUIDANCE_CYAN               (0x00001000)
+#define     WFS_IPM_GUIDANCE_MAGENTA            (0x00002000)
+#define     WFS_IPM_GUIDANCE_WHITE              (0x00004000)
+
+/* Values of WFSIPMCAPS.fwType */
+
+#define     WFS_IPM_TYPESINGLEMEDIAINPUT        (0x0001)
+#define     WFS_IPM_TYPEBUNCHMEDIAINPUT         (0x0002)
+
+/* Values of WFSIPMCAPS.fwRetractLocation,
+             WFSIPMPOSCAPS.fwRetractAreas,
+             WFSIPMRETRACTMEDIA.wRetractLocation and
+             WFSIPMRETRACTMEDIAOUT.wRetractLocation */
+
+#define     WFS_IPM_CTRLRETRACTTOBIN            (0x0001)
+#define     WFS_IPM_CTRLRETRACTTOTRANSPORT      (0x0002)
+#define     WFS_IPM_CTRLRETRACTTOSTACKER        (0x0004)
+#define     WFS_IPM_CTRLRETRACTTOREBUNCHER      (0x0008)
+
+/* Values of WFSIPMCAPS.fwResetControl and
+             WFSIPMRESET.wMediaControl */
+
+#define     WFS_IPM_RESETEJECT                  (0x0001)
+#define     WFS_IPM_RESETRETRACTTOBIN           (0x0002)
+#define     WFS_IPM_RESETRETRACTTOTRANSPORT     (0x0004)
+#define     WFS_IPM_RESETRETRACTTOREBUNCHER     (0x0008)
+
+/* Values of WFSIPMCAPS.fwImageType,
+             WFSIPMIMAGEREQUEST.wImageType and
+             WFSIPMIMAGEDATA.wImageType */
+
+#define     WFS_IPM_IMAGETIF                    (0x0001)
+#define     WFS_IPM_IMAGEWMF                    (0x0002)
+#define     WFS_IPM_IMAGEBMP                    (0x0004)
+#define     WFS_IPM_IMAGEJPG                    (0x0008)
+
+/* Values of WFSIPMCAPS.fwFrontImageColorFormat,
+             WFSIPMCAPS.fwBackImageColorFormat,
+             WFSIPMIMAGEREQUEST.wImageColorFormat and
+             WFSIPMIMAGEDATA.wImageColorFormat */
+
+#define     WFS_IPM_IMAGECOLORBINARY            (0x0001)
+#define     WFS_IPM_IMAGECOLORGRAYSCALE         (0x0002)
+#define     WFS_IPM_IMAGECOLORFULL              (0x0004)
+
+/* Values of WFSIPMCAPS.fwFrontScanColor,
+             WFSIPMCAPS.fwBackScanColor,
+             WFSIPMCAPS.wDefaultFrontScanColor,
+             WFSIPMCAPS.wDefaultBackScanColor,
+             WFSIPMIMAGEREQUEST.wImageScanColor and
+             WFSIPMIMAGEDATA.wImageScanColor */
+
+#define     WFS_IPM_SCANCOLORDEFAULT            (0x0000)
+#define     WFS_IPM_SCANCOLORRED                (0x0001)
+#define     WFS_IPM_SCANCOLORBLUE               (0x0002)
+#define     WFS_IPM_SCANCOLORGREEN              (0x0004)
+#define     WFS_IPM_SCANCOLORYELLOW             (0x0008)
+#define     WFS_IPM_SCANCOLORWHITE              (0x0010)
+
+/* Values of WFSIPMCAPS.fwCodelineFormat,
+             WFSIPMCODELINEMAPPING.wCodelineFormat,
+             WFSIPMCODELINEMAPPINGOUT.wCodelineFormat,
+             WFSIPMMEDIAINREQUEST.wCodelineFormat and
+             WFSIPMREADIMAGEIN.wCodelineFomat */
+
+#define     WFS_IPM_CODELINECMC7                (0x0001)
+#define     WFS_IPM_CODELINEE13B                (0x0002)
+#define     WFS_IPM_CODELINEOCR                 (0x0004)
+
+/* Values of WFSIPMCAPS.fwDataSource,
+             WFSIPMIMAGEREQUEST.wImageSource and
+             WFSIPMIMAGEDATA.wImageSource */
+
+#define     WFS_IPM_IMAGEFRONT                  (0x0001)
+#define     WFS_IPM_IMAGEBACK                   (0x0002)
+#define     WFS_IPM_CODELINE                    (0x0004)
+
+/* Values of WFSIPMCAPS.fwReturnedItemsProcessing */
+
+#define     WFS_IPM_RETITEMENDORSE              (0x0001)
+#define     WFS_IPM_RETITEMENDORSEIMAGE         (0x0002)
+
+/* Values of WFSIPMMEDIABIN.fwType */
+
+#define     WFS_IPM_TYPEMEDIAIN                 (0x0001)
+#define     WFS_IPM_TYPERETRACT                 (0x0002)
+
+/* Values of WFSIPMMEDIABIN.wMediaType */
+
+#define     WFS_IPM_MEDIATYPIPM                 (0x0001)
+#define     WFS_IPM_MEDIATYPCOMPOUND            (0x0002)
+
+/* Values of WFSIPMMEDIABIN.usStatus */
+
+#define     WFS_IPM_STATMBOK                    (1)
+#define     WFS_IPM_STATMBFULL                  (2)
+#define     WFS_IPM_STATMBHIGH                  (3)
+#define     WFS_IPM_STATMBINOP                  (4)
+#define     WFS_IPM_STATMBMISSING               (5)
+#define     WFS_IPM_STATMBUNKNOWN               (6)
+
+/* Values of WFSIPMTRANSSTATUS.wMediaInTransaction */
+
+#define     WFS_IPM_MITOK                       (0)
+#define     WFS_IPM_MITACTIVE                   (1)
+#define     WFS_IPM_MITROLLBACK                 (2)
+#define     WFS_IPM_MITROLLBACKAFTERDEPOSIT     (3)
+#define     WFS_IPM_MITRETRACT                  (4)
+#define     WFS_IPM_MITFAILURE                  (5)
+#define     WFS_IPM_MITUNKNOWN                  (6)
+#define     WFS_IPM_MITRESET                    (7)
+
+/* Values of WFSIPMMEDIASTATUS.wMediaLocation */
+
+#define     WFS_IPM_LOCATION_DEVICE             (0)
+#define     WFS_IPM_LOCATION_BIN                (1)
+#define     WFS_IPM_LOCATION_CUSTOMER           (2)
+#define     WFS_IPM_LOCATION_UNKNOWN            (3)
+
+/* Values of WFSIPMMEDIASTATUS.wCustomerAccess */
+
+#define     WFS_IPM_ACCESSUNKNOWN               (0)
+#define     WFS_IPM_ACCESSCUSTOMER              (1)
+#define     WFS_IPM_ACCESSNONE                  (2)
+
+/* Values of WFSIPMIMAGEDATA.wImageStatus */
+
+#define     WFS_IPM_DATAOK                      (0)
+#define     WFS_IPM_DATASRCNOTSUPP              (1)
+#define     WFS_IPM_DATASRCMISSING              (2)
+
+/* Values of WFSIPMMEDIASTATUS.wMagneticReadIndicator and
+             WFSIPMMEDIADATA.wMagneticReadIndicator */
+
+#define     WFS_IPM_MRI_MICR                    (0)
+#define     WFS_IPM_MRI_NOT_MICR                (1)
+#define     WFS_IPM_MRI_NO_MICR                 (2)
+#define     WFS_IPM_MRI_UNKNOWN                 (3)
+#define     WFS_IPM_MRI_NOTMICRFORMAT           (4)
+#define     WFS_IPM_MRI_NOT_READ                (5)
+
+/* Values of WFSIPMCAPS.fwInsertOrientation,
+             WFSIPMMEDIASTATUS.fwInsertOrientation and
+             WFSIPMMEDIADATA.fwInsertOrientation */
+
+#define     WFS_IPM_INSUNKNOWN                  (0x0000)
+#define     WFS_IPM_INSCODELINERIGHT            (0x0001)
+#define     WFS_IPM_INSCODELINELEFT             (0x0002)
+#define     WFS_IPM_INSCODELINEBOTTOM           (0x0004)
+#define     WFS_IPM_INSCODELINETOP              (0x0008)
+#define     WFS_IPM_INSFACEUP                   (0x0010)
+#define     WFS_IPM_INSFACEDOWN                 (0x0020)
+
+/* Values of WFSIPMMEDIASTATUS.wMediaValidity and
+             WFSIPMMEDIADATA.wMediaValidity */
+
+#define     WFS_IPM_ITEMOK                      (0)
+#define     WFS_IPM_ITEMSUSPECT                 (1)
+#define     WFS_IPM_ITEMUNKNOWN                 (2)
+#define     WFS_IPM_ITEMNOVALIDATION            (3)
+
+/* Values of WFSIPMSUPPLYREPLEN.fwSupplyReplen */
+
+#define     WFS_IPM_REPLEN_TONER                (0x0001)
+#define     WFS_IPM_REPLEN_INK                  (0x0002)
+
+/* Values of WFSIPMMEDIAREFUSED.wReason */
+
+#define     WFS_IPM_REFUSED_FOREIGNITEMS        (1)
+#define     WFS_IPM_REFUSED_STACKERFULL         (2)
+#define     WFS_IPM_REFUSED_CODELINEINVALID     (3)
+#define     WFS_IPM_REFUSED_INVALIDMEDIA        (4)
+#define     WFS_IPM_REFUSED_TOOLONG             (5)
+#define     WFS_IPM_REFUSED_TOOSHORT            (6)
+#define     WFS_IPM_REFUSED_TOOWIDE             (7)
+#define     WFS_IPM_REFUSED_TOONARROW           (8)
+#define     WFS_IPM_REFUSED_TOOTHICK            (9)
+#define     WFS_IPM_REFUSED_INVALIDORIENTATION  (10)
+#define     WFS_IPM_REFUSED_DOUBLEDETECT        (11)
+#define     WFS_IPM_REFUSED_REFUSEPOSFULL       (12)
+#define     WFS_IPM_REFUSED_RETURNBLOCKED       (13)
+#define     WFS_IPM_REFUSED_INVALIDBUNCH        (14)
+#define     WFS_IPM_REFUSED_OTHERITEM           (15)
+#define     WFS_IPM_REFUSED_OTHERBUNCH          (16)
+#define     WFS_IPM_REFUSED_JAMMING             (17)
+#define     WFS_IPM_REFUSED_METAL               (18)
+
+/* Values of WFSIPMMEDIAREFUSED.wMediaLocation and
+             WFSIPMPRESENTMEDIA.wPosition */
+
+#define     WFS_IPM_REFUSE_INPUT                (1)
+#define     WFS_IPM_REFUSE_REFUSED              (2)
+#define     WFS_IPM_REFUSE_REBUNCHER            (3)
+#define     WFS_IPM_REFUSE_STACKER              (4)
+
+/* Values of WFSIPMMBERROR.wFailure */
+
+#define     WFS_IPM_MEDIABINJAMMED              (1)
+#define     WFS_IPM_MEDIABINERROR               (2)
+#define     WFS_IPM_MEDIABINFULL                (3)
+#define     WFS_IPM_MEDIABINNOTCONF             (4)
+#define     WFS_IPM_MEDIABININVALID             (5)
+#define     WFS_IPM_MEDIABINCONFIG              (6)
+#define     WFS_IPM_MEDIABINFEEDPROBLEM         (7)
+
+/* Values of WFSIPMMEDIAREJECTED.wReason */
+
+#define     WFS_IPM_REJECT_LONG                 (1)
+#define     WFS_IPM_REJECT_THICK                (2)
+#define     WFS_IPM_REJECT_DOUBLE               (3)
+#define     WFS_IPM_REJECT_TRANSPORT            (4)
+#define     WFS_IPM_REJECT_SHUTTER              (5)
+#define     WFS_IPM_REJECT_REMOVED              (6)
+#define     WFS_IPM_REJECT_METAL                (7)
+#define     WFS_IPM_REJECT_FOREIGNITEMS         (8)
+#define     WFS_IPM_REJECT_OTHER                (9)
+
+/* Values of WFSIPMSCANNERTHRESHOLD.wScanner */
+
+#define     WFS_IPM_FRONTSCANNER                (1)
+#define     WFS_IPM_BACKSCANNER                 (2)
+
+/* Values of WFSIPMSTATUS.wAntiFraudModule */
+
+#define     WFS_IPM_AFMNOTSUPP                  (0)
+#define     WFS_IPM_AFMOK                       (1)
+#define     WFS_IPM_AFMINOP                     (2)
+#define     WFS_IPM_AFMDEVICEDETECTED           (3)
+#define     WFS_IPM_AFMUNKNOWN                  (4)
+
+/* XFS IPM Errors */
+
+#define     WFS_ERR_IPM_NOMEDIAPRESENT          (-(IPM_SERVICE_OFFSET + 1))
+#define     WFS_ERR_IPM_MEDIABINFULL            (-(IPM_SERVICE_OFFSET + 2))
+#define     WFS_ERR_IPM_STACKERFULL             (-(IPM_SERVICE_OFFSET + 3))
+#define     WFS_ERR_IPM_SHUTTERFAIL             (-(IPM_SERVICE_OFFSET + 4))
+#define     WFS_ERR_IPM_MEDIAJAMMED             (-(IPM_SERVICE_OFFSET + 5))
+#define     WFS_ERR_IPM_FILEIOERROR             (-(IPM_SERVICE_OFFSET + 6))
+#define     WFS_ERR_IPM_INKOUT                  (-(IPM_SERVICE_OFFSET + 7))
+#define     WFS_ERR_IPM_TONEROUT                (-(IPM_SERVICE_OFFSET + 8))
+#define     WFS_ERR_IPM_SCANNERINOP             (-(IPM_SERVICE_OFFSET + 9))
+#define     WFS_ERR_IPM_MICRINOP                (-(IPM_SERVICE_OFFSET + 10))
+#define     WFS_ERR_IPM_SEQUENCEINVALID         (-(IPM_SERVICE_OFFSET + 11))
+#define     WFS_ERR_IPM_INVALID_PORT            (-(IPM_SERVICE_OFFSET + 12))
+#define     WFS_ERR_IPM_FOREIGNITEMSDETECTED    (-(IPM_SERVICE_OFFSET + 13))
+#define     WFS_ERR_IPM_INVALIDMEDIAID          (-(IPM_SERVICE_OFFSET + 14))
+#define     WFS_ERR_IPM_MEDIABINERROR           (-(IPM_SERVICE_OFFSET + 15))
+#define     WFS_ERR_IPM_POSITIONNOTEMPTY        (-(IPM_SERVICE_OFFSET + 16))
+#define     WFS_ERR_IPM_INVALIDBIN              (-(IPM_SERVICE_OFFSET + 17))
+#define     WFS_ERR_IPM_NOBIN                   (-(IPM_SERVICE_OFFSET + 18))
+#define     WFS_ERR_IPM_REFUSEDITEMS            (-(IPM_SERVICE_OFFSET + 19))
+#define     WFS_ERR_IPM_ALLBINSFULL             (-(IPM_SERVICE_OFFSET + 20))
+#define     WFS_ERR_IPM_FEEDERNOTEMPTY          (-(IPM_SERVICE_OFFSET + 21))
+#define     WFS_ERR_IPM_MEDIAREJECTED           (-(IPM_SERVICE_OFFSET + 22))
+#define     WFS_ERR_IPM_FEEDERINOPERATIVE       (-(IPM_SERVICE_OFFSET + 23))
+#define     WFS_ERR_IPM_MEDIAPRESENT            (-(IPM_SERVICE_OFFSET + 24))
+#define     WFS_ERR_IPM_POWERSAVETOOSHORT       (-(IPM_SERVICE_OFFSET + 25))
+#define     WFS_ERR_IPM_POWERSAVEMEDIAPRESENT   (-(IPM_SERVICE_OFFSET + 26))
+#define     WFS_ERR_IPM_CASHINACTIVE            (-(IPM_SERVICE_OFFSET + 27))
+#define     WFS_ERR_IPM_MEDIAINACTIVE           (-(IPM_SERVICE_OFFSET + 28))
+
+/*=================================================================*/
+/* IPM Info Command Structures */
+/*=================================================================*/
+
+typedef struct _wfs_ipm_pos
+{
+    WORD                   wShutter;
+    WORD                   wPositionStatus;
+    WORD                   wTransport;
+    WORD                   wTransportMediaStatus;
+} WFSIPMPOS, *LPWFSIPMPOS;
+
+typedef struct _wfs_ipm_status
+{
+    WORD                   fwDevice;
+    WORD                   wAcceptor;
+    WORD                   wMedia;
+    WORD                   wToner;
+    WORD                   wInk;
+    WORD                   wFrontImageScanner;
+    WORD                   wBackImageScanner;
+    WORD                   wMICRReader;
+    WORD                   wStacker;
+    WORD                   wReBuncher;
+    WORD                   wMediaFeeder;
+    LPWFSIPMPOS            *lppPositions;
+    DWORD                  dwGuidLights[WFS_IPM_GUIDLIGHTS_SIZE];
+    LPSTR                  lpszExtra;
+    WORD                   wDevicePosition;
+    USHORT                 usPowerSaveRecoveryTime;
+    WORD                   wMixedMode;
+    WORD                   wAntiFraudModule;
+} WFSIPMSTATUS, *LPWFSIPMSTATUS;
+
+typedef struct _wfs_ipm_print_size
+{
+    WORD                   wRows;
+    WORD                   wCols;
+} WFSIPMPRINTSIZE, *LPWFSIPMPRINTSIZE;
+
+typedef struct _wfs_ipm_pos_caps
+{
+    BOOL                   bItemsTakenSensor;
+    BOOL                   bItemsInsertedSensor;
+    WORD                   fwRetractAreas;
+} WFSIPMPOSCAPS, *LPWFSIPMPOSCAPS;
+
+/* WFS_INF_IPM_CAPABILITIES output structures */
+
+typedef struct _wfs_ipm_caps
+{
+    WORD                   wClass;
+    WORD                   fwType;
+    BOOL                   bCompound;
+    USHORT                 usMaxMediaOnStacker;
+    LPWFSIPMPRINTSIZE      lpPrintSize;
+    BOOL                   bStamp;
+    BOOL                   bRescan;
+    BOOL                   bPresentControl;
+    BOOL                   bApplicationRefuse;
+    WORD                   fwRetractLocation;
+    WORD                   fwResetControl;
+    BOOL                   bRetractCountsItems;
+    WORD                   fwImageType;
+    WORD                   fwFrontImageColorFormat;
+    WORD                   fwBackImageColorFormat;
+    WORD                   fwFrontScanColor;
+    WORD                   wDefaultFrontScanColor;
+    WORD                   fwBackScanColor;
+    WORD                   wDefaultBackScanColor;
+    WORD                   fwCodelineFormat;
+    WORD                   fwDataSource;
+    WORD                   fwInsertOrientation;
+    LPWFSIPMPOSCAPS        *lppPositions;
+    DWORD                  dwGuidLights[WFS_IPM_GUIDLIGHTS_SIZE];
+    LPSTR                  lpszExtra;
+    BOOL                   bPowerSaveControl;
+    BOOL                   bImageAfterEndorse;
+    WORD                   fwReturnedItemsProcessing;
+    WORD                   wMixedMode;
+    BOOL                   bMixedDepositAndRollback;
+    BOOL                   bAntiFraudModule;
+} WFSIPMCAPS, *LPWFSIPMCAPS;
+
+typedef struct _wfs_ipm_hex_data
+{
+    USHORT                 usLength;
+    LPBYTE                 lpbData;
+} WFSIPMXDATA, *LPWFSIPMXDATA;
+
+/* WFS_INF_IPM_CODELINE_MAPPING input and output structures */
+
+typedef struct _wfs_ipm_codeline_mapping
+{
+    WORD                   wCodelineFormat;
+} WFSIPMCODELINEMAPPING, *LPWFSIPMCODELINEMAPPING;
+
+typedef struct _wfs_ipm_codeline_mapping_out
+{
+    WORD                   wCodelineFormat;
+    LPWFSIPMXDATA          lpxCharMapping;
+} WFSIPMCODELINEMAPPINGOUT, *LPWFSIPMCODELINEMAPPINGOUT;
+
+/* WFS_INF_IPM_MEDIA_BIN_INFO output structures */
+
+typedef struct _wfs_ipm_media_bin
+{
+    USHORT                 usBinNumber;
+    LPSTR                  lpstrPositionName;
+    WORD                   fwType;
+    WORD                   wMediaType;
+    LPSTR                  lpstrBinID;
+    ULONG                  ulMediaInCount;
+    ULONG                  ulCount;
+    ULONG                  ulRetractOperations;
+    BOOL                   bHardwareSensors;
+    ULONG                  ulMaximumItems;
+    ULONG                  ulMaximumRetractOperations;
+    USHORT                 usStatus;
+    LPSTR                  lpszExtra;
+} WFSIPMMEDIABIN, *LPWFSIPMMEDIABIN;
+
+typedef struct _wfs_ipm_media_bin_info
+{
+    USHORT                 usCount;
+    LPWFSIPMMEDIABIN       *lppMediaBin;
+} WFSIPMMEDIABININFO, *LPWFSIPMMEDIABININFO;
+
+typedef struct _wfs_ipm_image_data
+{
+    WORD                   wImageSource;
+    WORD                   wImageType;
+    WORD                   wImageColorFormat;
+    WORD                   wImageScanColor;
+    WORD                   wImageStatus;
+    LPSTR                  lpszImageFile;
+} WFSIPMIMAGEDATA, *LPWFSIPMIMAGEDATA;
+
+typedef struct _wfs_ipm_media_size
+{
+    ULONG                  ulSizeX;
+    ULONG                  ulSizeY;
+} WFSIPMMEDIASIZE, *LPWFSIPMMEDIASIZE;
+
+typedef struct _wfs_ipm_mediastatus
+{
+    USHORT                 usMediaID;
+    WORD                   wMediaLocation;
+    USHORT                 usBinNumber;
+    ULONG                  ulCodelineDataLength;
+    LPBYTE                 lpbCodelineData;
+    WORD                   wMagneticReadIndicator;
+    LPWFSIPMIMAGEDATA      *lppImage;
+    WORD                   fwInsertOrientation;
+    LPWFSIPMMEDIASIZE      lpMediaSize;
+    WORD                   wMediaValidity;
+    WORD                   wCustomerAccess;
+} WFSIPMMEDIASTATUS, *LPWFSIPMMEDIASTATUS;
+
+/* WFS_INF_IPM_TRANSACTION_STATUS output structures */
+
+typedef struct _wfs_ipm_trans_status
+{
+    WORD                   wMediaInTransaction;
+    USHORT                 usMediaOnStacker;
+    USHORT                 usLastMediaInTotal;
+    USHORT                 usLastMediaAddedToStacker;
+    USHORT                 usTotalItems;
+    USHORT                 usTotalItemsRefused;
+    USHORT                 usTotalBunchesRefused;
+    LPWFSIPMMEDIASTATUS    *lppMediaInfo;
+    LPSTR                  lpszExtra;
+} WFSIPMTRANSSTATUS, *LPWFSIPMTRANSSTATUS;
+
+/*=================================================================*/
+/* IPM Execute Command Structures */
+/*=================================================================*/
+
+typedef struct _wfs_ipm_image_request
+{
+    WORD                   wImageSource;
+    WORD                   wImageType;
+    WORD                   wImageColorFormat;
+    WORD                   wImageScanColor;
+    LPSTR                  lpszImagePath;
+} WFSIPMIMAGEREQUEST, *LPWFSIPMIMAGEREQUEST;
+
+typedef struct _wfs_ipm_media_in_request
+{
+    WORD                   wCodelineFormat;
+    LPWFSIPMIMAGEREQUEST   *lppImage;
+    USHORT                 usMaxMediaOnStacker;
+    BOOL                   bApplicationRefuse;
+} WFSIPMMEDIAINREQUEST, *LPWFSIPMMEDIAINREQUEST;
+
+typedef struct _wfs_ipm_media_in
+{
+    USHORT                 usMediaOnStacker;
+    USHORT                 usLastMedia;
+    USHORT                 usLastMediaOnStacker;
+    WORD                   wMediaFeeder;
+} WFSIPMMEDIAIN, *LPWFSIPMMEDIAIN;
+
+/* WFS_CMD_IPM_MEDIA_IN_END structures */
+
+typedef struct _wfs_ipm_media_in_end
+{
+    USHORT                 usItemsReturned;
+    USHORT                 usItemsRefused;
+    USHORT                 usBunchesRefused;
+    LPWFSIPMMEDIABININFO   lpMediaBinInfo;
+} WFSIPMMEDIAINEND, *LPWFSIPMMEDIAINEND;
+
+typedef struct _wfs_ipm_read_image_request
+{
+    USHORT                 usMediaID;
+    WORD                   wCodelineFormat;
+    LPWFSIPMIMAGEREQUEST   *lppImage;
+} WFSIPMREADIMAGEIN, *LPWFSIPMREADIMAGEIN;
+
+typedef struct _wfs_ipm_mediadata
+{
+    USHORT                 usMediaID;
+    ULONG                  ulCodelineDataLength;
+    LPBYTE                 lpbCodelineData;
+    WORD                   wMagneticReadIndicator;
+    LPWFSIPMIMAGEDATA      *lppImage;
+    WORD                   fwInsertOrientation;
+    LPWFSIPMMEDIASIZE      lpMediaSize;
+    WORD                   wMediaValidity;
+} WFSIPMMEDIADATA, *LPWFSIPMMEDIADATA;
+
+/* WFS_CMD_IPM_SET_DESTINATION structures */
+
+typedef struct _wfs_ipm_set_destination
+{
+    USHORT                 usMediaID;
+    USHORT                 usBinNumber;
+} WFSIPMSETDESTINATION, *LPWFSIPMSETDESTINATION;
+
+typedef struct _wfs_ipm_next_item_out
+{
+    WORD                   wMediaFeeder;
+} WFSIPMNEXTITEMOUT, *LPWFSIPMNEXTITEMOUT;
+
+/* WFS_CMD_IPM_PRESENT_MEDIA structures */
+
+typedef struct _wfs_ipm_present_media
+{
+    WORD                   wPosition;
+} WFSIPMPRESENTMEDIA, *LPWFSIPMPRESENTMEDIA;
+
+/* WFS_CMD_IPM_RETRACT_MEDIA structures */
+
+typedef struct _wfs_ipm_retract_media
+{
+    WORD                   wRetractLocation;
+    USHORT                 usBinNumber;
+} WFSIPMRETRACTMEDIA, *LPWFSIPMRETRACTMEDIA;
+
+typedef struct _wfs_ipm_retract_media_out
+{
+    USHORT                 usMedia;
+    WORD                   wRetractLocation;
+    USHORT                 usBinNumber;
+} WFSIPMRETRACTMEDIAOUT, *LPWFSIPMRETRACTMEDIAOUT;
+
+/* WFS_CMD_IPM_PRINT_TEXT structures */
+
+typedef struct _wfs_ipm_print_text
+{
+    USHORT                 usMediaID;
+    BOOL                   bStamp;
+    LPWSTR                 lpszPrintData;
+} WFSIPMPRINTTEXT, *LPWFSIPMPRINTTEXT;
+
+/* WFS_CMD_IPM_GET_IMAGE_AFTER_PRINT structures */
+
+typedef struct _wfs_ipm_get_image_after_print
+{
+    USHORT                 usMediaID;
+    LPWFSIPMIMAGEREQUEST   *lppImage;
+} WFSIPMGETIMAGEAFTERPRINT, *LPWFSIPMGETIMAGEAFTERPRINT;
+
+/* WFS_CMD_IPM_ACCEPT_ITEM structures */
+
+typedef struct _wfs_ipm_accept_item
+{
+    BOOL                   bAccept;
+} WFSIPMACCEPTITEM, *LPWFSIPMACCEPTITEM;
+
+/* WFS_CMD_IPM_RESET structures */
+
+typedef struct _wfs_ipm_reset
+{
+    WORD                   wMediaControl;
+    USHORT                 usBinNumber;
+} WFSIPMRESET, *LPWFSIPMRESET;
+
+/* WFS_CMD_IPM_SUPPLY_REPLENISH structures */
+
+typedef struct _wfs_ipm_supply_replen
+{
+    WORD                   fwSupplyReplen;
+} WFSIPMSUPPLYREPLEN, *LPWFSIPMSUPPLYREPLEN;
+
+/* WFS_CMD_IPM_SET_GUIDANCE_LIGHT structures */
+
+typedef struct _wfs_ipm_set_guidlight
+{
+    WORD                   wGuidLight;
+    DWORD                  dwCommand;
+} WFSIPMSETGUIDLIGHT, *LPWFSIPMSETGUIDLIGHT;
+
+/* WFS_CMD_IPM_POWER_SAVE_CONTROL structure */
+
+typedef struct _wfs_ipm_power_save_control
+{
+    USHORT                 usMaxPowerSaveRecoveryTime;
+} WFSIPMPOWERSAVECONTROL, *LPWFSIPMPOWERSAVECONTROL;
+
+typedef struct _wfs_ipm_setmode
+{
+    WORD                   wMixedMode;
+} WFSIPMSETMODE, *LPWFSIPMSETMODE;
+
+/*=================================================================*/
+/* IPM Message Structures */
+/*=================================================================*/
+
+/* WFS_EXEE_IPM_MEDIABINERROR structure */
+
+typedef struct _wfs_ipm_mb_error
+{
+    WORD                   wFailure;
+    LPWFSIPMMEDIABIN       lpMediaBin;
+} WFSIPMMBERROR, *LPWFSIPMMBERROR;
+
+/* WFS_SRVE_IPM_MEDIATAKEN structure */
+
+typedef struct _wfs_ipm_position
+{
+    WORD                   wPosition;
+} WFSIPMPOSITION, *LPWFSIPMPOSITION;
+
+/* WFS_USRE_IPM_TONERTHRESHOLD and
+   WFS_USRE_IPM_INKTHRESHOLD structures */
+
+typedef struct _wfs_ipm_threshold
+{
+    WORD                   wThreshold;
+} WFSIPMTHRESHOLD, *LPWFSIPMTHRESHOLD;
+
+/* WFS_USRE_IPM_SCANNERTHRESHOLD structure */
+
+typedef struct _wfs_ipm_scanner_threshold
+{
+    WORD                   wScanner;
+    WORD                   wThreshold;
+} WFSIPMSCANNERTHRESHOLD, *LPWFSIPMSCANNERTHRESHOLD;
+
+/* WFS_SRVE_IPM_MEDIADETECTED structure */
+
+typedef struct _wfs_ipm_media_detected
+{
+    WORD                   wPosition;
+    USHORT                 usRetractBinNumber;
+} WFSIPMMEDIADETECTED, *LPWFSIPMMEDIADETECTED;
+
+/* WFS_EXEE_IPM_MEDIAPRESENTED structure */
+
+typedef struct _wfs_ipm_media_presented
+{
+    WORD                   wPosition;
+    USHORT                 usBunchIndex;
+    USHORT                 usTotalBunches;
+} WFSIPMMEDIAPRESENTED, *LPWFSIPMMEDIAPRESENTED;
+
+/* WFS_EXEE_IPM_MEDIAREFUSED structure */
+
+typedef struct _wfs_ipm_media_refused
+{
+    WORD                   wReason;
+    WORD                   wMediaLocation;
+    BOOL                   bPresentRequired;
+    LPWFSIPMMEDIASIZE      lpMediaSize;
+} WFSIPMMEDIAREFUSED, *LPWFSIPMMEDIAREFUSED;
+
+/* WFS_EXEE_IPM_MEDIAREJECTED structure */
+
+typedef struct _wfs_ipm_media_rejected
+{
+    WORD                   wReason;
+} WFSIPMMEDIAREJECTED, *LPWFSIPMMEDIAREJECTED;
+
+/* WFS_SRVE_IPM_DEVICEPOSITION structure */
+
+typedef struct _wfs_ipm_device_position
+{
+    WORD                   wPosition;
+} WFSIPMDEVICEPOSITION, *LPWFSIPMDEVICEPOSITION;
+
+/* WFS_SRVE_IPM_POWERSAVECHANGE structure */
+
+typedef struct _wfs_ipm_power_save_change
+{
+    USHORT                 usPowerSaveRecoveryTime;
+} WFSIPMPOWERSAVECHANGE, *LPWFSIPMPOWERSAVECHANGE;
+
+/*   restore alignment   */
+#pragma pack(pop)
+
+#ifdef __cplusplus
+}       /*extern "C"*/
+#endif
+
+#endif    /* __INC_XFSIPM__H */

--- a/cen/320/xfsptr.h
+++ b/cen/320/xfsptr.h
@@ -600,7 +600,8 @@ typedef struct _wfs_ptr_caps
     WORD                 fwCoercivityType;
     WORD                 fwControlPassbook;
     WORD                 wPrintSides;
-    BOOL                 bAntiFraudModule; } WFSPTRCAPS, *LPWFSPTRCAPS;
+    BOOL                 bAntiFraudModule;
+} WFSPTRCAPS, *LPWFSPTRCAPS;
 
 typedef struct _wfs_frm_header
 {

--- a/cen/320/xfsspi.h
+++ b/cen/320/xfsspi.h
@@ -35,17 +35,17 @@ HRESULT WINAPI WFPExecute ( HSERVICE hService, DWORD dwCommand, LPVOID lpCmdData
 
 HRESULT WINAPI WFPGetInfo ( HSERVICE hService, DWORD dwCategory, LPVOID lpQueryDetails, DWORD dwTimeOut, HWND hWnd, REQUESTID ReqID);
 
-HRESULT  WINAPI WFPLock ( HSERVICE hService, DWORD dwTimeOut, HWND hWnd, REQUESTID ReqID);
+HRESULT WINAPI WFPLock ( HSERVICE hService, DWORD dwTimeOut, HWND hWnd, REQUESTID ReqID);
 
-HRESULT  WINAPI WFPOpen ( HSERVICE hService, LPSTR lpszLogicalName, HAPP hApp, LPSTR lpszAppID, DWORD dwTraceLevel, DWORD dwTimeOut, HWND hWnd, REQUESTID ReqID, HPROVIDER hProvider, DWORD dwSPIVersionsRequired, LPWFSVERSION lpSPIVersion, DWORD dwSrvcVersionsRequired, LPWFSVERSION lpSrvcVersion);
+HRESULT WINAPI WFPOpen ( HSERVICE hService, LPSTR lpszLogicalName, HAPP hApp, LPSTR lpszAppID, DWORD dwTraceLevel, DWORD dwTimeOut, HWND hWnd, REQUESTID ReqID, HPROVIDER hProvider, DWORD dwSPIVersionsRequired, LPWFSVERSION lpSPIVersion, DWORD dwSrvcVersionsRequired, LPWFSVERSION lpSrvcVersion);
 
-HRESULT  WINAPI WFPRegister ( HSERVICE hService,  DWORD dwEventClass, HWND hWndReg, HWND hWnd, REQUESTID ReqID);
+HRESULT WINAPI WFPRegister ( HSERVICE hService, DWORD dwEventClass, HWND hWndReg, HWND hWnd, REQUESTID ReqID);
 
-HRESULT  WINAPI WFPSetTraceLevel ( HSERVICE hService, DWORD dwTraceLevel);
+HRESULT WINAPI WFPSetTraceLevel ( HSERVICE hService, DWORD dwTraceLevel);
 
-HRESULT  WINAPI WFPUnloadService ( void );
+HRESULT WINAPI WFPUnloadService ( void);
 
-HRESULT  WINAPI WFPUnlock ( HSERVICE hService, HWND hWnd, REQUESTID ReqID);
+HRESULT WINAPI WFPUnlock ( HSERVICE hService, HWND hWnd, REQUESTID ReqID);
 
 /*   restore alignment   */
 #pragma pack(pop)

--- a/cen/320/xfsspiptr.h
+++ b/cen/320/xfsspiptr.h
@@ -24,9 +24,8 @@ typedef HRESULT (WINAPI * WFPLockFunc)(HSERVICE hService, DWORD dwTimeOut, HWND 
 typedef HRESULT (WINAPI * WFPOpenFunc)(HSERVICE hService, LPSTR lpszLogicalName, HAPP hApp, LPSTR lpszAppID, DWORD dwTraceLevel, DWORD dwTimeOut, HWND hWnd, REQUESTID ReqID, HPROVIDER hProvider, DWORD dwSPIVersionsRequired, LPWFSVERSION lpSPIVersion, DWORD dwSrvcVersionsRequired, LPWFSVERSION lpSrvcVersion);
 typedef HRESULT (WINAPI * WFPRegisterFunc)(HSERVICE hService, DWORD dwEventClass, HWND hWndReg, HWND hWnd, REQUESTID ReqID);
 typedef HRESULT (WINAPI * WFPSetTraceLevelFunc)(HSERVICE hService, DWORD dwTraceLevel);
-typedef HRESULT (WINAPI * WFPUnloadServiceFunc)();
+typedef HRESULT (WINAPI * WFPUnloadServiceFunc)(void);
 typedef HRESULT (WINAPI * WFPUnlockFunc)(HSERVICE hService, HWND hWnd, REQUESTID ReqID);
-
 
 /*   restore alignment   */
 #pragma pack(pop)

--- a/cen/320/xfsttu.h
+++ b/cen/320/xfsttu.h
@@ -1,0 +1,486 @@
+/******************************************************************************
+*                                                                             *
+* xfsttu.h      XFS - Text Terminal Unit (TTU) definitions                    *
+*                                                                             *
+*               Version 3.20  (March 02 2011)                                 *
+*                                                                             *
+******************************************************************************/
+
+#ifndef __INC_XFSTTU__H
+#define __INC_XFSTTU__H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "xfsapi.h"
+
+/*   be aware of alignment   */
+#pragma pack(push,1)
+
+
+/* values of WFSTTUCAPS.wClass */
+
+#define     WFS_SERVICE_CLASS_TTU               (7)
+#define     WFS_SERVICE_CLASS_NAME_TTU          "TTU"
+#define     WFS_SERVICE_CLASS_VERSION_TTU       (0x1403) /* Version 3.20 */
+
+#define     TTU_SERVICE_OFFSET                  (WFS_SERVICE_CLASS_TTU * 100)
+
+/* TTU Info Commands */
+
+#define     WFS_INF_TTU_STATUS                  (TTU_SERVICE_OFFSET + 1)
+#define     WFS_INF_TTU_CAPABILITIES            (TTU_SERVICE_OFFSET + 2)
+#define     WFS_INF_TTU_FORM_LIST               (TTU_SERVICE_OFFSET + 3)
+#define     WFS_INF_TTU_QUERY_FORM              (TTU_SERVICE_OFFSET + 4)
+#define     WFS_INF_TTU_QUERY_FIELD             (TTU_SERVICE_OFFSET + 5)
+#define     WFS_INF_TTU_KEY_DETAIL              (TTU_SERVICE_OFFSET + 6)
+
+/* TTU Command Verbs */
+
+#define     WFS_CMD_TTU_BEEP                    (TTU_SERVICE_OFFSET + 1)
+#define     WFS_CMD_TTU_CLEARSCREEN             (TTU_SERVICE_OFFSET + 2)
+#define     WFS_CMD_TTU_DISPLIGHT               (TTU_SERVICE_OFFSET + 3)
+#define     WFS_CMD_TTU_SET_LED                 (TTU_SERVICE_OFFSET + 4)
+#define     WFS_CMD_TTU_SET_RESOLUTION          (TTU_SERVICE_OFFSET + 5)
+#define     WFS_CMD_TTU_WRITE_FORM              (TTU_SERVICE_OFFSET + 6)
+#define     WFS_CMD_TTU_READ_FORM               (TTU_SERVICE_OFFSET + 7)
+#define     WFS_CMD_TTU_WRITE                   (TTU_SERVICE_OFFSET + 8)
+#define     WFS_CMD_TTU_READ                    (TTU_SERVICE_OFFSET + 9)
+#define     WFS_CMD_TTU_RESET                   (TTU_SERVICE_OFFSET + 10)
+#define     WFS_CMD_TTU_DEFINE_KEYS             (TTU_SERVICE_OFFSET + 11)
+#define     WFS_CMD_TTU_POWER_SAVE_CONTROL      (TTU_SERVICE_OFFSET + 12)
+#define     WFS_CMD_TTU_SET_LED_EX              (TTU_SERVICE_OFFSET + 13)
+
+/* TTU Messages */
+
+#define    WFS_EXEE_TTU_FIELDERROR              (TTU_SERVICE_OFFSET + 1)
+#define    WFS_EXEE_TTU_FIELDWARNING            (TTU_SERVICE_OFFSET + 2)
+#define    WFS_EXEE_TTU_KEY                     (TTU_SERVICE_OFFSET + 3)
+#define    WFS_SRVE_TTU_DEVICEPOSITION          (TTU_SERVICE_OFFSET + 4)
+#define    WFS_SRVE_TTU_POWER_SAVE_CHANGE       (TTU_SERVICE_OFFSET + 5)
+
+/* Values of WFSTTUSTATUS.fwDevice */
+
+#define     WFS_TTU_DEVONLINE                   WFS_STAT_DEVONLINE
+#define     WFS_TTU_DEVOFFLINE                  WFS_STAT_DEVOFFLINE
+#define     WFS_TTU_DEVPOWEROFF                 WFS_STAT_DEVPOWEROFF
+#define     WFS_TTU_DEVBUSY                     WFS_STAT_DEVBUSY
+#define     WFS_TTU_DEVNODEVICE                 WFS_STAT_DEVNODEVICE
+#define     WFS_TTU_DEVHWERROR                  WFS_STAT_DEVHWERROR
+#define     WFS_TTU_DEVUSERERROR                WFS_STAT_DEVUSERERROR
+#define     WFS_TTU_DEVFRAUDATTEMPT             WFS_STAT_DEVFRAUDATTEMPT
+#define     WFS_TTU_DEVPOTENTIALFRAUD           WFS_STAT_DEVPOTENTIALFRAUD
+
+/* Values of WFSTTUSTATUS.wKeyboard */
+
+#define     WFS_TTU_KBDNA                       (0)
+#define     WFS_TTU_KBDON                       (1)
+#define     WFS_TTU_KBDOFF                      (2)
+
+/* Values of WFSTTUSTATUS.wKeyLock */
+
+#define     WFS_TTU_KBDLOCKNA                   (0)
+#define     WFS_TTU_KBDLOCKON                   (1)
+#define     WFS_TTU_KBDLOCKOFF                  (2)
+
+#define     WFS_TTU_LEDS_MAX                    (8)
+
+/* Values of WFSTTUSTATUS.fwLEDs
+             WFSTTUSTATUS.lpLEDEx.lpdwLEDs
+             WFSTTUCAPS.lpLEDEx.lpdwLEDs
+             WFSTTUSETLEDS.fwCommand */
+
+#define     WFS_TTU_LEDNA                       (0x0000)
+#define     WFS_TTU_LEDOFF                      (0x0001)
+#define     WFS_TTU_LEDSLOWFLASH                (0x0002)
+#define     WFS_TTU_LEDMEDIUMFLASH              (0x0004)
+#define     WFS_TTU_LEDQUICKFLASH               (0x0008)
+#define     WFS_TTU_LEDCONTINUOUS               (0x0080)
+
+/* Values of WFSTTUSTATUS.lpLEDEx.lpdwLEDs
+             WFSTTUCAPS.lpLEDEx.lpdwLEDs
+             WFSTTUSETLEDSEX.dwCommand */
+
+#define     WFS_TTU_LEDRED                      (0x00000100)
+#define     WFS_TTU_LEDGREEN                    (0x00000200)
+#define     WFS_TTU_LEDYELLOW                   (0x00000400)
+#define     WFS_TTU_LEDBLUE                     (0x00000800)
+#define     WFS_TTU_LEDCYAN                     (0x00001000)
+#define     WFS_TTU_LEDMAGENTA                  (0x00002000)
+#define     WFS_TTU_LEDWHITE                    (0x00004000)
+
+/* Values of WFSTTUSTATUS.wDevicePosition
+             WFSTTUDEVICEPOSITION.wPosition */
+
+#define     WFS_TTU_DEVICEINPOSITION            (0)
+#define     WFS_TTU_DEVICENOTINPOSITION         (1)
+#define     WFS_TTU_DEVICEPOSUNKNOWN            (2)
+#define     WFS_TTU_DEVICEPOSNOTSUPP            (3)
+
+/* values of WFSTTUSTATUS.wAntiFraudModule */
+
+#define     WFS_TTU_AFMNOTSUPP                  (0)
+#define     WFS_TTU_AFMOK                       (1)
+#define     WFS_TTU_AFMINOP                     (2)
+#define     WFS_TTU_AFMDEVICEDETECTED           (3)
+#define     WFS_TTU_AFMUNKNOWN                  (4)
+
+/* Values of WFSTTUCAPS.fwType */
+
+#define     WFS_TTU_FIXED                       (0x0001)
+#define     WFS_TTU_REMOVABLE                   (0x0002)
+
+/* Values of WFSTTUCAPS.fwCharSupport
+           WFSTTUWRITE.fwCharSupport */
+
+#define     WFS_TTU_ASCII                       (0x0001)
+#define     WFS_TTU_UNICODE                     (0x0002)
+
+/* Values of WFSTTUFRMFIELD.fwType */
+
+#define     WFS_TTU_FIELDTEXT                   (0)
+#define     WFS_TTU_FIELDINVISIBLE              (1)
+#define     WFS_TTU_FIELDPASSWORD               (2)
+
+/* Values of WFSTTUFRMFIELD.fwClass */
+
+#define     WFS_TTU_CLASSOPTIONAL               (0)
+#define     WFS_TTU_CLASSSTATIC                 (1)
+#define     WFS_TTU_CLASSREQUIRED               (2)
+
+/* Values of WFSTTUFRMFIELD.fwAccess */
+
+#define     WFS_TTU_ACCESSREAD                  (0x0001)
+#define     WFS_TTU_ACCESSWRITE                 (0x0002)
+
+/* Values of WFSTTUFRMFIELD.fwOverflow */
+
+#define     WFS_TTU_OVFTERMINATE                (0)
+#define     WFS_TTU_OVFTRUNCATE                 (1)
+#define     WFS_TTU_OVFOVERWRITE                (2)
+
+/* Values of WFSTTUWRITE.fwMode */
+
+#define     WFS_TTU_POSRELATIVE                 (0)
+#define     WFS_TTU_POSABSOLUTE                 (1)
+
+/* Values of WFSTTUWRITE.fwTextAttr */
+
+#define     WFS_TTU_TEXTUNDERLINE               (0x0001)
+#define     WFS_TTU_TEXTINVERTED                (0x0002)
+#define     WFS_TTU_TEXTFLASH                   (0x0004)
+
+/* Values of WFSTTUFRMREAD.fwEchoMode */
+
+#define     WFS_TTU_ECHOTEXT                    (0)
+#define     WFS_TTU_ECHOINVISIBLE               (1)
+#define     WFS_TTU_ECHOPASSWORD                (2)
+
+#define     WFS_TTU_BEEPOFF                     (0x0001)
+#define     WFS_TTU_BEEPKEYPRESS                (0x0002)
+#define     WFS_TTU_BEEPEXCLAMATION             (0x0004)
+#define     WFS_TTU_BEEPWARNING                 (0x0008)
+#define     WFS_TTU_BEEPERROR                   (0x0010)
+#define     WFS_TTU_BEEPCRITICAL                (0x0020)
+#define     WFS_TTU_BEEPCONTINUOUS              (0x0080)
+
+/* values of WFSTTUFIELDFAIL.wFailure */
+
+#define     WFS_TTU_FIELDREQUIRED               (0)
+#define     WFS_TTU_FIELDSTATICOVWR             (1)
+#define     WFS_TTU_FIELDOVERFLOW               (2)
+#define     WFS_TTU_FIELDNOTFOUND               (3)
+#define     WFS_TTU_FIELDNOTREAD                (4)
+#define     WFS_TTU_FIELDNOTWRITE               (5)
+#define     WFS_TTU_FIELDTYPENOTSUPPORTED       (6)
+#define     WFS_TTU_CHARSETFORM                 (7)
+
+/* values of WFSTTUKEYDETAIL.lpwCommandKeys */
+
+#define     WFS_TTU_NOKEY                       (0)
+#define     WFS_TTU_CK_ENTER                    (1)
+#define     WFS_TTU_CK_CANCEL                   (2)
+#define     WFS_TTU_CK_CLEAR                    (3)
+#define     WFS_TTU_CK_BACKSPACE                (4)
+#define     WFS_TTU_CK_HELP                     (5)
+#define     WFS_TTU_CK_00                       (6)
+#define     WFS_TTU_CK_000                      (7)
+#define     WFS_TTU_CK_ARROWUP                  (8)
+#define     WFS_TTU_CK_ARROWDOWN                (9)
+#define     WFS_TTU_CK_ARROWLEFT                (10)
+#define     WFS_TTU_CK_ARROWRIGHT               (11)
+#define     WFS_TTU_CK_OEM1                     (12)
+#define     WFS_TTU_CK_OEM2                     (13)
+#define     WFS_TTU_CK_OEM3                     (14)
+#define     WFS_TTU_CK_OEM4                     (15)
+#define     WFS_TTU_CK_OEM5                     (16)
+#define     WFS_TTU_CK_OEM6                     (17)
+#define     WFS_TTU_CK_OEM7                     (18)
+#define     WFS_TTU_CK_OEM8                     (19)
+#define     WFS_TTU_CK_OEM9                     (20)
+#define     WFS_TTU_CK_OEM10                    (21)
+#define     WFS_TTU_CK_OEM11                    (22)
+#define     WFS_TTU_CK_OEM12                    (23)
+#define     WFS_TTU_CK_FDK01                    (24)
+#define     WFS_TTU_CK_FDK02                    (25)
+#define     WFS_TTU_CK_FDK03                    (26)
+#define     WFS_TTU_CK_FDK04                    (27)
+#define     WFS_TTU_CK_FDK05                    (28)
+#define     WFS_TTU_CK_FDK06                    (29)
+#define     WFS_TTU_CK_FDK07                    (30)
+#define     WFS_TTU_CK_FDK08                    (31)
+#define     WFS_TTU_CK_FDK09                    (32)
+#define     WFS_TTU_CK_FDK10                    (33)
+#define     WFS_TTU_CK_FDK11                    (34)
+#define     WFS_TTU_CK_FDK12                    (35)
+#define     WFS_TTU_CK_FDK13                    (36)
+#define     WFS_TTU_CK_FDK14                    (37)
+#define     WFS_TTU_CK_FDK15                    (38)
+#define     WFS_TTU_CK_FDK16                    (39)
+#define     WFS_TTU_CK_FDK17                    (40)
+#define     WFS_TTU_CK_FDK18                    (41)
+#define     WFS_TTU_CK_FDK19                    (42)
+#define     WFS_TTU_CK_FDK20                    (43)
+#define     WFS_TTU_CK_FDK21                    (44)
+#define     WFS_TTU_CK_FDK22                    (45)
+#define     WFS_TTU_CK_FDK23                    (46)
+#define     WFS_TTU_CK_FDK24                    (47)
+#define     WFS_TTU_CK_FDK25                    (48)
+#define     WFS_TTU_CK_FDK26                    (49)
+#define     WFS_TTU_CK_FDK27                    (50)
+#define     WFS_TTU_CK_FDK28                    (51)
+#define     WFS_TTU_CK_FDK29                    (52)
+#define     WFS_TTU_CK_FDK30                    (53)
+#define     WFS_TTU_CK_FDK31                    (54)
+#define     WFS_TTU_CK_FDK32                    (55)
+
+/* XFS TTU Errors */ 
+
+#define WFS_ERR_TTU_FIELDERROR                  (-(TTU_SERVICE_OFFSET + 1))
+#define WFS_ERR_TTU_FIELDINVALID                (-(TTU_SERVICE_OFFSET + 2))
+#define WFS_ERR_TTU_FIELDNOTFOUND               (-(TTU_SERVICE_OFFSET + 3))
+#define WFS_ERR_TTU_FIELDSPECFAILURE            (-(TTU_SERVICE_OFFSET + 4))
+#define WFS_ERR_TTU_FORMINVALID                 (-(TTU_SERVICE_OFFSET + 5))
+#define WFS_ERR_TTU_FORMNOTFOUND                (-(TTU_SERVICE_OFFSET + 6))
+#define WFS_ERR_TTU_INVALIDLED                  (-(TTU_SERVICE_OFFSET + 7))
+#define WFS_ERR_TTU_KEYCANCELED                 (-(TTU_SERVICE_OFFSET + 8))
+#define WFS_ERR_TTU_MEDIAOVERFLOW               (-(TTU_SERVICE_OFFSET + 9))
+#define WFS_ERR_TTU_RESNOTSUPP                  (-(TTU_SERVICE_OFFSET + 10))
+#define WFS_ERR_TTU_CHARSETDATA                 (-(TTU_SERVICE_OFFSET + 11))
+#define WFS_ERR_TTU_KEYINVALID                  (-(TTU_SERVICE_OFFSET + 12))
+#define WFS_ERR_TTU_KEYNOTSUPPORTED             (-(TTU_SERVICE_OFFSET + 13))
+#define WFS_ERR_TTU_NOACTIVEKEYS                (-(TTU_SERVICE_OFFSET + 14))
+#define WFS_ERR_TTU_POWERSAVETOOSHORT           (-(TTU_SERVICE_OFFSET + 15))
+
+/*=================================================================*/
+/* TTU Info Command Structures */
+/*=================================================================*/
+
+typedef struct _wfs_ttu_led_ex
+{
+    USHORT                usNumOfLEDs;
+    LPDWORD               lpdwLEDs;
+} WFSTTULEDEX, *LPWFSTTULEDEX;
+
+typedef struct _wfs_ttu_status
+{
+    WORD                  fwDevice;
+    WORD                  wKeyboard;
+    WORD                  wKeylock;
+    WORD                  wLEDs[WFS_TTU_LEDS_MAX];
+    WORD                  wDisplaySizeX;
+    WORD                  wDisplaySizeY;
+    LPSTR                 lpszExtra;
+    WORD                  wDevicePosition;
+    USHORT                usPowerSaveRecoveryTime;
+    LPWFSTTULEDEX         lpLEDEx;
+    WORD                  wAntiFraudModule;
+} WFSTTUSTATUS, *LPWFSTTUSTATUS;
+
+typedef struct _wfs_ttu_resolution
+{
+    WORD                  wSizeX;
+    WORD                  wSizeY;
+} WFSTTURESOLUTION, *LPWFSTTURESOLUTION;
+
+typedef struct _wfs_ttu_caps
+{
+    WORD                  wClass;
+    WORD                  fwType;
+    LPWFSTTURESOLUTION    *lppResolutions;
+    WORD                  wNumOfLEDs;
+    BOOL                  bKeyLock;
+    BOOL                  bDisplayLight;
+    BOOL                  bCursor;
+    BOOL                  bForms;
+    WORD                  fwCharSupport;
+    LPSTR                 lpszExtra;
+    BOOL                  bPowerSaveControl;
+    LPWFSTTULEDEX         lpLEDEx;
+    BOOL                  bAntiFraudModule;
+} WFSTTUCAPS, *LPWFSTTUCAPS;
+
+typedef struct _wfs_ttu_frm_header
+{
+    LPSTR                 lpszFormName;
+    WORD                  wWidth;
+    WORD                  wHeight;
+    WORD                  wVersionMajor;
+    WORD                  wVersionMinor;
+    WORD                  fwCharSupport;
+    LPSTR                 lpszFields;
+    WORD                  wLanguageID;
+} WFSTTUFRMHEADER, *LPWFSTTUFRMHEADER;
+
+typedef struct _wfs_ttu_query_field
+{
+    LPSTR                 lpszFormName;
+    LPSTR                 lpszFieldName;
+} WFSTTUQUERYFIELD, *LPWFSTTUQUERYFIELD;
+
+typedef struct _wfs_ttu_frm_field
+{
+    LPSTR                 lpszFieldName;
+    WORD                  fwType;
+    WORD                  fwClass;
+    WORD                  fwAccess;
+    WORD                  fwOverflow;
+    LPSTR                 lpszFormat;
+    WORD                  wLanguageID;
+} WFSTTUFRMFIELD, *LPWFSTTUFRMFIELD;
+
+typedef struct _wfs_ttu_key_detail
+{
+    LPSTR                 lpszKeys;
+    LPWSTR                lpwszUNICODEKeys;
+    LPWORD                lpwCommandKeys;
+} WFSTTUKEYDETAIL, *LPWFSTTUKEYDETAIL;
+
+typedef struct _wfs_ttu_clear_screen
+{
+    WORD                  wPositionX;
+    WORD                  wPositionY;
+    WORD                  wWidth;
+    WORD                  wHeight;
+} WFSTTUCLEARSCREEN, *LPWFSTTUCLEARSCREEN;
+
+typedef struct _wfs_ttu_disp_light
+{
+    BOOL                  bMode;
+} WFSTTUDISPLIGHT, * LPWFSTTUDISPLIGHT;
+
+typedef struct _wfs_ttu_set_leds
+{
+    WORD                  wLED;
+    WORD                  fwCommand;
+} WFSTTUSETLEDS, *LPWFSTTUSETLEDS;
+
+typedef struct _wfs_ttu_write_form
+{
+    LPSTR                 lpszFormName;
+    BOOL                  bClearScreen;
+    LPSTR                 lpszFields;
+    LPWSTR                lpszUNICODEFields;
+} WFSTTUWRITEFORM, *LPWFSTTUWRITEFORM;
+
+typedef struct _wfs_ttu_read_form
+{
+    LPSTR                 lpszFormName;
+    LPSTR                 lpszFieldNames;
+} WFSTTUREADFORM, *LPWFSTTUREADFORM;
+
+typedef struct _wfs_ttu_read_form_out
+{
+    LPSTR                 lpszFields;
+    LPWSTR                lpszUNICODEFields;
+} WFSTTUREADFORMOUT, *LPWFSTTUREADFORMOUT;
+
+typedef struct _wfs_ttu_def_keys
+{
+    LPSTR                 lpszActiveKeys;
+    LPWSTR                lpwszActiveUNICODEKeys;
+    LPWORD                lpwActiveCommandKeys;
+    LPWORD                lpwTerminateCommandKeys;
+} WFSTTUDEFKEYS, *LPWFSTTUDEFKEYS;
+
+typedef struct _wfs_ttu_write
+{
+    WORD                  fwMode;
+    SHORT                 wPosX;
+    SHORT                 wPosY;
+    WORD                  fwTextAttr;
+    LPSTR                 lpsText;
+    LPWSTR                lpsUNICODEText;
+} WFSTTUWRITE, *LPWFSTTUWRITE;
+
+typedef struct _wfs_ttu_read
+{
+    WORD                  wNumOfChars;
+    WORD                  fwMode;
+    SHORT                 wPosX;
+    SHORT                 wPosY;
+    WORD                  fwEchoMode;
+    WORD                  fwEchoAttr;
+    BOOL                  bCursor;
+    BOOL                  bFlush;
+    BOOL                  bAutoEnd;
+    LPSTR                 lpszActiveKeys;
+    LPWSTR                lpwszActiveUNICODEKeys;
+    LPWORD                lpwActiveCommandKeys;
+    LPWORD                lpwTerminateCommandKeys;
+} WFSTTUREAD, *LPWFSTTUREAD;
+
+typedef struct _wfs_ttu_read_in
+{
+    LPSTR                 lpszInput;
+    LPWSTR                lpszUNICODEInput;
+} WFSTTUREADIN, *LPWFSTTUREADIN;
+
+typedef struct _wfs_ttu_power_save_control
+{
+    USHORT                usMaxPowerSaveRecoveryTime;
+} WFSTTUPOWERSAVECONTROL, *LPWFSTTUPOWERSAVECONTROL;
+
+typedef struct _wfs_ttu_set_leds_ex
+{
+    USHORT                usLED;
+    DWORD                 dwCommand;
+} WFSTTUSETLEDSEX, *LPWFSTTUSETLEDSEX;
+
+/*=================================================================*/
+/* TTU Message Structures */
+/*=================================================================*/
+
+typedef struct _wfs_ttu_field_failure
+{
+    LPSTR                 lpszFormName;
+    LPSTR                 lpszFieldName;
+    WORD                  wFailure;
+} WFSTTUFIELDFAIL, *LPWFSTTUFIELDFAIL;
+
+typedef struct _wfs_ttu_key
+{
+    CHAR                  cKey;
+    WORD                  wUNICODEKey;
+    WORD                  wCommandKey;
+} WFSTTUKEY, *LPWFSTTUKEY;
+
+typedef struct _wfs_ttu_device_position
+{
+    WORD                  wPosition;
+} WFSTTUDEVICEPOSITION, *LPWFSTTUDEVICEPOSITION;
+
+typedef struct _wfs_ttu_power_save_change
+{
+    USHORT                usPowerSaveRecoveryTime;
+} WFSTTUPOWERSAVECHANGE, *LPWFSTTUPOWERSAVECHANGE;
+
+/*   restore alignment   */
+#pragma pack(pop)
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /* __INC_XFSTTU__H */


### PR DESCRIPTION
The classes ALM, CAM, CEU, CRD, DEP and IPM were missing.  Added `(void)` to all functions with no parameters. Also fixed some formatting issues. 