### PR TITLE
Fix major/minor types to BYTE

### DIFF
--- a/xfs/version.cpp
+++ b/xfs/version.cpp
@@ -14,8 +14,8 @@
 using namespace XFS;
 
 Version::Version(WORD wVersion) :
-  _major(static_cast< WORD >(wVersion & 0xff)),
-  _minor(static_cast< WORD >((wVersion >> 8) & 0xff))
+  _major(static_cast<BYTE>(wVersion & 0xff)),
+  _minor(static_cast<BYTE>(wVersion >> 8))
 {
 
 }
@@ -29,15 +29,15 @@ Version::Version(BYTE bMajor, BYTE bMinor) :
 
 WORD Version::value() const
 {
-  return static_cast< WORD >((minor() << 8) | major());
+  return static_cast<WORD>((static_cast<WORD>(minor()) << 8) | static_cast<WORD>(major()));
 }
 
-WORD Version::major() const
+BYTE Version::major() const
 {
   return _major;
 }
 
-WORD Version::minor() const
+BYTE Version::minor() const
 {
   return _minor;
 }
@@ -70,8 +70,8 @@ std::ostream &XFS::operator<<(std::ostream &out, const Version &v)
 }
 
 VersionRange::VersionRange(DWORD dwVersion) :
-  _start(dwVersion >> 16),
-  _end(dwVersion & 0xffff)
+  _start(static_cast<WORD>(dwVersion >> 16)),
+  _end(static_cast<WORD>(dwVersion & 0xffff))
 {
 
 }

--- a/xfs/version.hpp
+++ b/xfs/version.hpp
@@ -21,8 +21,8 @@ namespace XFS
 {
   class Version : private Comparable< Version >
   {
-    WORD _major;
-    WORD _minor;
+    BYTE _major;
+    BYTE _minor;
 
   public:
     explicit Version(WORD wVersion);
@@ -30,8 +30,8 @@ namespace XFS
 
     WORD value() const;
 
-    WORD major() const;
-    WORD minor() const;
+    BYTE major() const;
+    BYTE minor() const;
 
     static Version min(BYTE bMajor);
     static Version max(BYTE bMajor);


### PR DESCRIPTION
The major/minor version fields are currently handled as WORDs, but they are actually BYTEs.